### PR TITLE
HB-3817 Pass price granularity for video

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -1,8 +1,13 @@
 import * as utils from '../src/utils';
 import {registerBidder} from '../src/adapters/bidderFactory';
+import { Renderer } from '../src/Renderer';
+import { VIDEO, BANNER } from '../src/mediaTypes';
+
 const BIDDER_CODE = 'grid';
 const ENDPOINT_URL = '//grid.bidswitch.net/hb';
 const TIME_TO_LIVE = 360;
+const RENDERER_URL = '//cdn.adnxs.com/renderer/video/ANOutstreamVideo.js';
+
 const LOG_ERROR_MESS = {
   noAuid: 'Bid from response has no auid parameter - ',
   noAdm: 'Bid from response has no adm parameter - ',
@@ -16,6 +21,7 @@ const LOG_ERROR_MESS = {
 };
 export const spec = {
   code: BIDDER_CODE,
+  supportedMediaTypes: [ BANNER, VIDEO ],
   /**
    * Determines whether or not the given bid request is valid.
    *
@@ -124,19 +130,39 @@ function _addBidResponse(serverBid, bidsMap, bidResponses) {
     const awaitingBids = bidsMap[serverBid.auid];
     if (awaitingBids) {
       awaitingBids.forEach(bid => {
+        const size = bid.sizes[0];
+        if (serverBid.w && serverBid.h) {
+          size[0] = serverBid.w;
+          size[1] = serverBid.h;
+        }
         const bidResponse = {
           requestId: bid.bidId, // bid.bidderRequestId,
           bidderCode: spec.code,
           cpm: serverBid.price,
-          width: serverBid.w,
-          height: serverBid.h,
+          width: size[0],
+          height: size[1],
           creativeId: serverBid.auid, // bid.bidId,
           currency: 'USD',
           netRevenue: false,
           ttl: TIME_TO_LIVE,
-          ad: serverBid.adm,
           dealId: serverBid.dealid
         };
+        if (serverBid.content_type === 'video') {
+          bidResponse.vastXml = serverBid.adm;
+          bidResponse.mediaType = VIDEO;
+          bidResponse.adResponse = {
+            content: bidResponse.vastXml
+          };
+          if (!bid.renderer && (!bid.mediaTypes || !bid.mediaTypes.video || bid.mediaTypes.video.context === 'outstream')) {
+            bidResponse.renderer = createRenderer(bidResponse, {
+              id: bid.bidId,
+              url: RENDERER_URL
+            });
+          }
+        } else {
+          bidResponse.ad = serverBid.adm;
+          bidResponse.mediaType = BANNER;
+        }
         bidResponses.push(bidResponse);
       });
     } else {
@@ -146,6 +172,31 @@ function _addBidResponse(serverBid, bidsMap, bidResponses) {
   if (errorMessage) {
     utils.logError(errorMessage);
   }
+}
+
+function outstreamRender (bid) {
+  bid.renderer.push(() => {
+    window.ANOutstreamVideo.renderAd({
+      targetId: bid.adUnitCode,
+      adResponse: bid.adResponse
+    });
+  });
+}
+
+function createRenderer (bid, rendererParams) {
+  const renderer = Renderer.install({
+    id: rendererParams.id,
+    url: rendererParams.url,
+    loaded: false
+  });
+
+  try {
+    renderer.setRender(outstreamRender);
+  } catch (err) {
+    utils.logWarn('Prebid Error calling setRender on renderer', err);
+  }
+
+  return renderer;
 }
 
 registerBidder(spec);

--- a/modules/gridBidAdapter.md
+++ b/modules/gridBidAdapter.md
@@ -7,6 +7,7 @@ Maintainer: grid-tech@themediagrid.com
 # Description
 
 Module that connects to Grid demand source to fetch bids.
+Grid bid adapter supports Banner and Video (instream and outstream).
 
 # Test Parameters
 ```
@@ -35,6 +36,19 @@ Module that connects to Grid demand source to fetch bids.
                        }
                    }
                ]
-           }
+           },
+           {
+               code: 'test-div',
+               sizes: [[728, 90]],
+               mediaTypes: { video: {} },
+               bids: [
+                   {
+                       bidder: "grid",
+                       params: {
+                           uid: 11
+                       }
+                   }
+               ]
+          }
        ];
 ```

--- a/modules/iasBidAdapter.js
+++ b/modules/iasBidAdapter.js
@@ -103,7 +103,7 @@ function interpretResponse(serverResponse, request) {
     height: 200,
     creativeId: 434,
     dealId: 42,
-    currency: 'usd',
+    currency: 'USD',
     netRevenue: true,
     ttl: 360
   };

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -1,12 +1,14 @@
 import { registerBidder } from '../src/adapters/bidderFactory';
-import { parseSizesInput, logError, generateUUID, isEmpty, deepAccess } from '../src/utils';
+import { parseSizesInput, logError, generateUUID, isEmpty, deepAccess, logWarn, logMessage } from '../src/utils';
 import { BANNER, VIDEO } from '../src/mediaTypes';
 import { config } from '../src/config';
+import { Renderer } from '../src/Renderer';
 
 const BIDDER_CODE = 'sonobi';
 const STR_ENDPOINT = 'https://apex.go.sonobi.com/trinity.json';
 const PAGEVIEW_ID = generateUUID();
 const SONOBI_DIGITRUST_KEY = 'fhnS5drwmH';
+const OUTSTREAM_REDNERER_URL = 'https://mtrx.go.sonobi.com/sbi_outstream_renderer.js';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -107,7 +109,6 @@ export const spec = {
     const bidResponse = serverResponse.body;
     const bidsReturned = [];
     const referrer = bidderRequest.data.ref;
-
     if (Object.keys(bidResponse.slots).length === 0) {
       return bidsReturned;
     }
@@ -115,7 +116,16 @@ export const spec = {
     Object.keys(bidResponse.slots).forEach(slot => {
       const bid = bidResponse.slots[slot];
       const bidId = _getBidIdFromTrinityKey(slot);
-      const mediaType = (bid.sbi_ct === 'video') ? 'video' : null;
+      const bidRequest = _findBidderRequest(bidderRequest.bidderRequests, bidId);
+      let mediaType = null;
+      if (bid.sbi_ct === 'video') {
+        mediaType = 'video';
+        const context = deepAccess(bidRequest, 'mediaTypes.video.context');
+        if (context === 'outstream') {
+          mediaType = 'outstream';
+        }
+      }
+
       const createCreative = _creative(mediaType, referrer);
       if (bid.sbi_aid && bid.sbi_mouse && bid.sbi_size) {
         const [
@@ -145,6 +155,21 @@ export const spec = {
           delete bids.ad;
           delete bids.width;
           delete bids.height;
+        } else if (mediaType === 'outstream' && bidRequest) {
+          bids.mediaType = 'video';
+          bids.vastUrl = createCreative(bidResponse.sbi_dc, bid.sbi_aid);
+          bids.renderer = newRenderer(bidRequest.adUnitCode, bids, deepAccess(
+            bidRequest,
+            'renderer.options'
+          ));
+          let videoSize = deepAccess(bidRequest, 'params.sizes');
+          if (Array.isArray(videoSize) && Array.isArray(videoSize[0])) { // handle case of multiple sizes
+            videoSize = videoSize[0] // Only take the first size for outstream
+          }
+          if (videoSize) {
+            bids.width = videoSize[0];
+            bids.height = videoSize[1];
+          }
         }
         bidsReturned.push(bids);
       }
@@ -170,6 +195,14 @@ export const spec = {
   }
 };
 
+function _findBidderRequest(bidderRequests, bidId) {
+  for (let i = 0; i < bidderRequests.length; i++) {
+    if (bidderRequests[i].bidId === bidId) {
+      return bidderRequests[i];
+    }
+  }
+}
+
 function _validateSize (bid) {
   if (bid.params.sizes) {
     return parseSizesInput(bid.params.sizes).join(',');
@@ -192,7 +225,7 @@ function _validateFloor (bid) {
 }
 
 const _creative = (mediaType, referer) => (sbiDc, sbiAid) => {
-  if (mediaType === 'video') {
+  if (mediaType === 'video' || mediaType === 'outstream') {
     return _videoCreative(sbiDc, sbiAid, referer)
   }
   const src = `https://${sbiDc}apex.go.sonobi.com/sbi.js?aid=${sbiAid}&as=null&ref=${encodeURIComponent(referer)}`;
@@ -245,6 +278,49 @@ function _getDigiTrustObject(key) {
     return null;
   }
   return digiTrustId;
+}
+
+function newRenderer(adUnitCode, bid, rendererOptions = {}) {
+  const renderer = Renderer.install({
+    id: bid.aid,
+    url: OUTSTREAM_REDNERER_URL,
+    config: rendererOptions,
+    loaded: false,
+    adUnitCode
+  });
+
+  try {
+    renderer.setRender(outstreamRender);
+  } catch (err) {
+    logWarn('Prebid Error calling setRender on renderer', err);
+  }
+
+  renderer.setEventHandlers({
+    impression: () => logMessage('Sonobi outstream video impression event'),
+    loaded: () => logMessage('Sonobi outstream video loaded event'),
+    ended: () => {
+      logMessage('Sonobi outstream renderer video event');
+      // document.querySelector(`#${adUnitCode}`).style.display = 'none';
+    }
+  });
+  return renderer;
+}
+
+function outstreamRender(bid) {
+  // push to render queue because SbiOutstreamRenderer may not be loaded yet
+  bid.renderer.push(() => {
+    const [
+      width,
+      height
+    ] = bid.getSize().split('x');
+    const renderer = new window.SbiOutstreamRenderer();
+    renderer.init({
+      vastUrl: bid.vastUrl,
+      height,
+      width,
+    });
+    renderer.setRootElement(bid.adUnitCode);
+  });
 }
 
 registerBidder(spec);

--- a/modules/trionBidAdapter.js
+++ b/modules/trionBidAdapter.js
@@ -147,7 +147,7 @@ export function setStorageData(key, item) {
 
 export function acceptPostMessage(e) {
   var message = e.data || '';
-  if (message.indexOf(BASE_KEY + 'userId') !== 0) {
+  if (!message.indexOf || !message.split || message.indexOf(BASE_KEY + 'userId') !== 0) {
     return;
   }
   var intT = message.split(BASE_KEY + 'userId=')[1];

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -326,6 +326,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
           const message = `Error trying to write ad. Ad render call ad id ${id} was prevented from writing to the main document.`;
           emitAdRenderFail(PREVENT_WRITING_ON_MAIN_DOCUMENT, message, bid);
         } else if (ad) {
+          doc.open('text/html', 'replace');
           doc.write(ad);
           doc.close();
           setRenderSize(doc, width, height);

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -128,7 +128,7 @@ describe('TheMediaGrid Adapter', function () {
 
   describe('interpretResponse', function () {
     const responses = [
-      {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 1, 'h': 250, 'w': 300}], 'seat': '1'},
+      {'bid': [{'price': 1.15, 'adm': '<div>test content 1</div>', 'auid': 1, 'h': 250, 'w': 300, dealid: 11}], 'seat': '1'},
       {'bid': [{'price': 0.5, 'adm': '<div>test content 2</div>', 'auid': 2, 'h': 90, 'w': 728}], 'seat': '1'},
       {'bid': [{'price': 0, 'auid': 3, 'h': 250, 'w': 300}], 'seat': '1'},
       {'bid': [{'price': 0, 'adm': '<div>test content 4</div>', 'h': 250, 'w': 300}], 'seat': '1'},
@@ -157,12 +157,13 @@ describe('TheMediaGrid Adapter', function () {
           'requestId': '659423fff799cb',
           'cpm': 1.15,
           'creativeId': 1,
-          'dealId': undefined,
+          'dealId': 11,
           'width': 300,
           'height': 250,
           'ad': '<div>test content 1</div>',
           'bidderCode': 'grid',
           'currency': 'USD',
+          'mediaType': 'banner',
           'netRevenue': false,
           'ttl': 360,
         }
@@ -214,12 +215,13 @@ describe('TheMediaGrid Adapter', function () {
           'requestId': '300bfeb0d71a5b',
           'cpm': 1.15,
           'creativeId': 1,
-          'dealId': undefined,
+          'dealId': 11,
           'width': 300,
           'height': 250,
           'ad': '<div>test content 1</div>',
           'bidderCode': 'grid',
           'currency': 'USD',
+          'mediaType': 'banner',
           'netRevenue': false,
           'ttl': 360,
         },
@@ -227,12 +229,13 @@ describe('TheMediaGrid Adapter', function () {
           'requestId': '5703af74d0472a',
           'cpm': 1.15,
           'creativeId': 1,
-          'dealId': undefined,
+          'dealId': 11,
           'width': 300,
           'height': 250,
           'ad': '<div>test content 1</div>',
           'bidderCode': 'grid',
           'currency': 'USD',
+          'mediaType': 'banner',
           'netRevenue': false,
           'ttl': 360,
         },
@@ -246,12 +249,94 @@ describe('TheMediaGrid Adapter', function () {
           'ad': '<div>test content 2</div>',
           'bidderCode': 'grid',
           'currency': 'USD',
+          'mediaType': 'banner',
           'netRevenue': false,
           'ttl': 360,
         }
       ];
 
       const result = spec.interpretResponse({'body': {'seatbid': [responses[0], responses[1]]}}, request);
+      expect(result).to.deep.equal(expectedResponse);
+    });
+
+    it('should get correct video bid response', function () {
+      const bidRequests = [
+        {
+          'bidder': 'grid',
+          'params': {
+            'uid': '1'
+          },
+          'adUnitCode': 'adunit-code-1',
+          'sizes': [[300, 250], [300, 600]],
+          'bidId': '659423fff799cb',
+          'bidderRequestId': '5f2009617a7c0a',
+          'auctionId': '1cbd2feafe5e8b',
+          'mediaTypes': {
+            'video': {
+              'context': 'instream'
+            }
+          }
+        },
+        {
+          'bidder': 'grid',
+          'params': {
+            'uid': '2'
+          },
+          'adUnitCode': 'adunit-code-1',
+          'sizes': [[300, 250], [300, 600]],
+          'bidId': '2bc598e42b6a',
+          'bidderRequestId': '5f2009617a7c0a',
+          'auctionId': '1cbd2feafe5e8b',
+          'mediaTypes': {
+            'video': {
+              'context': 'instream'
+            }
+          }
+        }
+      ];
+      const response = [
+        {'bid': [{'price': 1.15, 'adm': '<VAST version=\"3.0\">\n<Ad id=\"21341234\"><\/Ad>\n<\/VAST>', 'auid': 1, content_type: 'video', w: 300, h: 600}], 'seat': '2'},
+        {'bid': [{'price': 1.00, 'adm': '<VAST version=\"3.0\">\n<Ad id=\"21331274\"><\/Ad>\n<\/VAST>', 'auid': 2, content_type: 'video'}], 'seat': '2'}
+      ];
+      const request = spec.buildRequests(bidRequests);
+      const expectedResponse = [
+        {
+          'requestId': '659423fff799cb',
+          'cpm': 1.15,
+          'creativeId': 1,
+          'dealId': undefined,
+          'width': 300,
+          'height': 600,
+          'bidderCode': 'grid',
+          'currency': 'USD',
+          'mediaType': 'video',
+          'netRevenue': false,
+          'ttl': 360,
+          'vastXml': '<VAST version=\"3.0\">\n<Ad id=\"21341234\"><\/Ad>\n<\/VAST>',
+          'adResponse': {
+            'content': '<VAST version=\"3.0\">\n<Ad id=\"21341234\"><\/Ad>\n<\/VAST>'
+          }
+        },
+        {
+          'requestId': '2bc598e42b6a',
+          'cpm': 1.00,
+          'creativeId': 2,
+          'dealId': undefined,
+          'width': 300,
+          'height': 250,
+          'bidderCode': 'grid',
+          'currency': 'USD',
+          'mediaType': 'video',
+          'netRevenue': false,
+          'ttl': 360,
+          'vastXml': '<VAST version=\"3.0\">\n<Ad id=\"21331274\"><\/Ad>\n<\/VAST>',
+          'adResponse': {
+            'content': '<VAST version=\"3.0\">\n<Ad id=\"21331274\"><\/Ad>\n<\/VAST>'
+          }
+        }
+      ];
+
+      const result = spec.interpretResponse({'body': {'seatbid': response}}, request);
       expect(result).to.deep.equal(expectedResponse);
     });
 

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -344,6 +344,20 @@ describe('SonobiBidAdapter', function () {
           'adUnitCode': 'adunit-code-3',
           'sizes': [[120, 600], [300, 600], [160, 600]],
           'bidId': '30b31c1838de1g'
+        },
+        {
+          'bidId': '30b31c1838de1zzzz',
+          'adUnitCode': 'outstream-dom-id',
+          bidder: 'sonobi',
+          mediaTypes: {
+            video: {
+              context: 'outstream'
+            }
+          },
+          params: {
+            placement_id: '92e95368e86639dbd86d',
+            sizes: [[640, 480]]
+          }
         }
       ]
     };
@@ -374,6 +388,17 @@ describe('SonobiBidAdapter', function () {
             'sbi_mouse': 1.07,
           },
           '/7780971/sparks_prebid_LB|30b31c1838de1g': {},
+          '30b31c1838de1zzzz': {
+            sbi_aid: 'force_1550072228_da1c5d030cb49150c5db8a2136175755',
+            sbi_apoc: 'premium',
+            sbi_ct: 'video',
+            sbi_curr: 'USD',
+            sbi_mouse: 1.25,
+            sbi_size: 'preroll',
+            'sbi_crid': 'somecrid',
+
+          }
+
         },
         'sbi_dc': 'mco-1-',
         'sbi_px': [{
@@ -404,13 +429,14 @@ describe('SonobiBidAdapter', function () {
         'cpm': 1.25,
         'width': 300,
         'height': 250,
-        'ad': 'https://mco-1-apex.go.sonobi.com/vast.xml?vid=30292e432662bd5f86d90774b944b038&ref=http%3A%2F%2Flocalhost%2F',
+        'vastUrl': 'https://mco-1-apex.go.sonobi.com/vast.xml?vid=30292e432662bd5f86d90774b944b038&ref=http%3A%2F%2Flocalhost%2F',
         'ttl': 500,
         'creativeId': '30292e432662bd5f86d90774b944b038',
         'netRevenue': true,
         'currency': 'USD',
         'dealId': 'dozerkey',
-        'aid': '30292e432662bd5f86d90774b944b038'
+        'aid': '30292e432662bd5f86d90774b944b038',
+        'mediaType': 'video'
       },
       {
         'requestId': '30b31c1838de1g',
@@ -423,6 +449,21 @@ describe('SonobiBidAdapter', function () {
         'netRevenue': true,
         'currency': 'USD',
         'aid': '30292e432662bd5f86d90774b944b038'
+      },
+      {
+        'requestId': '30b31c1838de1zzzz',
+        'cpm': 1.25,
+        'width': 640,
+        'height': 480,
+        'vastUrl': 'https://mco-1-apex.go.sonobi.com/vast.xml?vid=30292e432662bd5f86d90774b944b038&ref=http%3A%2F%2Flocalhost%2F',
+        'ttl': 500,
+        'creativeId': 'somecrid',
+        'netRevenue': true,
+        'currency': 'USD',
+        'dealId': 'dozerkey',
+        'aid': 'force_1550072228_da1c5d030cb49150c5db8a2136175755',
+        'mediaType': 'video',
+        renderer: () => {}
       },
     ];
 
@@ -437,7 +478,12 @@ describe('SonobiBidAdapter', function () {
         expect(resp.netRevenue).to.equal(prebidResponse[i].netRevenue);
         expect(resp.currency).to.equal(prebidResponse[i].currency);
         expect(resp.aid).to.equal(prebidResponse[i].aid);
-        if (resp.mediaType === 'video') {
+        if (resp.mediaType === 'video' && resp.renderer) {
+          expect(resp.vastUrl.indexOf('vast.xml')).to.be.greaterThan(0);
+          expect(resp.width).to.equal(prebidResponse[i].width);
+          expect(resp.height).to.equal(prebidResponse[i].height);
+          expect(resp.renderer).to.be.ok;
+        } else if (resp.mediaType === 'video') {
           expect(resp.vastUrl.indexOf('vast.xml')).to.be.greaterThan(0);
           expect(resp.ad).to.be.undefined;
           expect(resp.width).to.be.undefined;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -990,6 +990,7 @@ describe('Unit: Prebid Module', function () {
 
     beforeEach(function () {
       doc = {
+        open: sinon.spy(),
         write: sinon.spy(),
         close: sinon.spy(),
         defaultView: {
@@ -1040,6 +1041,7 @@ describe('Unit: Prebid Module', function () {
       });
       adResponse.ad = "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>";
       $$PREBID_GLOBAL$$.renderAd(doc, bidId);
+      assert.ok(doc.open, 'open method called');
       assert.ok(doc.write.calledWith(adResponse.ad), 'ad was written to doc');
       assert.ok(doc.close.called, 'close method called');
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [X] Other

## Description of change
An oversight was found in our implementation of PBS-based video – we need to pass the price granularity in the PBS requests.

Low granularity:
```
request.ext.prebid.targeting.pricegranularity: {
        "ranges": [{"max":5.00,"increment":0.50}]
}
```
Medium granularity:
```
request.ext.prebid.targeting.pricegranularity: {
        "ranges": [{"max":20.00,"increment":0.10}]
}
```
High granularity:
```
request.ext.prebid.targeting.pricegranularity: {
        "ranges": [{"max":20.00,"increment":0.01}]
}
```
Auto granularity:
```
request.ext.prebid.targeting.pricegranularity: {
        "ranges": [
            {"max":5.00,"increment":0.05},
            {"min":5.00, "max":10.00,"increment":0.10},
            {"min":10.00, "max":20.00,"increment":0.50}
        ]
}
```
Dense granularity:
```
request.ext.prebid.targeting.pricegranularity: {
        "ranges": [
            {"max":3.00,"increment":0.01},
            {"min":3.00,"max":8.00,"increment":0.05},
            {"min":8.00","max":20.00,"increment":0.50}
        ]
}
```
Custom granularity:
```
customConfigObj=pbjs.getConfig('priceGranularity');
request.ext.prebid.targeting.pricegranularity.ranges: customConfigObj.buckets
```
## Other information
[HB-3817](https://jira.rubiconproject.com/browse/HB-3817)