### PR TITLE
Add cache host to standard tagreting

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -438,22 +438,6 @@ export const callPrebidCache = hook('async', function(auctionInstance, bidRespon
           bidResponse.vastUrl = getCacheUrl(bidResponse.videoCacheKey);
         }
 
-        // try to use cache.url to add hb_cache_host and hb_cache_path to targeting
-        const cacheUrl = config.getConfig('cache.url');
-        if (cacheUrl && typeof cacheUrl === 'string') {
-          const parsedURL = document.createElement('a');
-          parsedURL.href = cacheUrl;
-
-          if (!bidResponse.adserverTargeting) {
-            bidResponse.adserverTargeting = {};
-          }
-          if (!bidResponse.adserverTargeting.hb_cache_host) {
-            bidResponse.adserverTargeting.hb_cache_host = parsedURL.hostname;
-          }
-          if (!bidResponse.adserverTargeting.hb_cache_path) {
-            bidResponse.adserverTargeting.hb_cache_path = parsedURL.pathname;
-          }
-        }
         addBidToAuction(auctionInstance, bidResponse);
         afterBidAdded();
       }

--- a/src/auction.js
+++ b/src/auction.js
@@ -585,6 +585,7 @@ export function getStandardBidderSettings(mediaType) {
     ]
 
     if (mediaType === 'video') {
+      // Adding hb_uuid + hb_cache_id
       [CONSTANTS.TARGETING_KEYS.UUID, CONSTANTS.TARGETING_KEYS.CACHE_ID].forEach(item => {
         bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING].push({
           key: item,
@@ -593,6 +594,21 @@ export function getStandardBidderSettings(mediaType) {
           }
         })
       });
+      // adding hb_cache_host + hb_cache_path
+      var cacheUrl = config.getConfig('cache.url');
+      if (cacheUrl && typeof cacheUrl === 'string') {
+        var parsedURL = document.createElement('a');
+        parsedURL.href = cacheUrl;
+        [[CONSTANTS.TARGETING_KEYS.CACHE_HOST, parsedURL.hostname],
+        [CONSTANTS.TARGETING_KEYS.CACHE_PATH, parsedURL.pathname]].forEach(item => {
+          bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING].push({
+            key: item[0],
+            val: function val(bidResponse) {
+              return utils.deepAccess(bidResponse, 'adserverTargeting.' + item[0]) ? bidResponse.adserverTargeting[item[0]] : item[1];
+            }
+          })
+        })
+      }
     }
   }
   return bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD];

--- a/src/auction.js
+++ b/src/auction.js
@@ -584,7 +584,7 @@ export function getStandardBidderSettings(mediaType) {
         var parsedURL = document.createElement('a');
         parsedURL.href = cacheUrl;
         [[CONSTANTS.TARGETING_KEYS.CACHE_HOST, parsedURL.hostname],
-        [CONSTANTS.TARGETING_KEYS.CACHE_PATH, parsedURL.pathname]].forEach(item => {
+          [CONSTANTS.TARGETING_KEYS.CACHE_PATH, parsedURL.pathname]].forEach(item => {
           bidderSettings[CONSTANTS.JSON_MAPPING.BD_SETTING_STANDARD][CONSTANTS.JSON_MAPPING.ADSERVER_TARGETING].push({
             key: item[0],
             val: function val(bidResponse) {

--- a/src/constants.json
+++ b/src/constants.json
@@ -64,7 +64,9 @@
     "SOURCE": "hb_source",
     "FORMAT": "hb_format",
     "UUID": "hb_uuid",
-    "CACHE_ID": "hb_cache_id"
+    "CACHE_ID": "hb_cache_id",
+    "CACHE_HOST": "hb_cache_host",
+    "CACHE_PATH": "hb_cache_path"
   },
   "NATIVE_KEYS": {
     "title": "hb_native_title",

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -142,6 +142,8 @@ describe('auctionmanager.js', function () {
       if (bid.mediaType === 'video') {
         expected[ CONSTANTS.TARGETING_KEYS.UUID ] = bid.videoCacheKey;
         expected[ CONSTANTS.TARGETING_KEYS.CACHE_ID ] = bid.videoCacheKey;
+        expected[ CONSTANTS.TARGETING_KEYS.CACHE_HOST ] = 'prebid.adnxs.com';
+        expected[ CONSTANTS.TARGETING_KEYS.CACHE_PATH ] = '/pbc/v1/cache';
       }
       if (!keys) {
         return expected;
@@ -167,6 +169,11 @@ describe('auctionmanager.js', function () {
     });
 
     it('No bidder level configuration defined - default for video', function () {
+      config.setConfig({
+        cache: {
+          url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        }
+      });
       $$PREBID_GLOBAL$$.bidderSettings = {};
       let videoBid = utils.deepClone(bid);
       videoBid.mediaType = 'video';
@@ -229,6 +236,11 @@ describe('auctionmanager.js', function () {
     });
 
     it('Custom configuration for all bidders with video bid', function () {
+      config.setConfig({
+        cache: {
+          url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        }
+      });
       let videoBid = utils.deepClone(bid);
       videoBid.mediaType = 'video';
       videoBid.videoCacheKey = 'abc123def';
@@ -288,7 +300,14 @@ describe('auctionmanager.js', function () {
       };
 
       let expected = getDefaultExpected(videoBid);
+      // Since we are effectively overwriting the bidderSettings above...
+      // we are not including the new host / path logic. So we will expect them to be gone.
+      delete expected['hb_cache_host'];
+      delete expected['hb_cache_path'];
       let response = getKeyValueTargetingPairs(videoBid.bidderCode, videoBid);
+
+      console.log('EXPECTED: \n', JSON.stringify(expected, null, 2))
+      console.log('response: \n', JSON.stringify(response, null, 2))
       assert.deepEqual(response, expected);
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
