### PR TITLE
User ID module refactored with submodules as separate files

### DIFF
--- a/modules/idSystemPubCommonId.js
+++ b/modules/idSystemPubCommonId.js
@@ -1,0 +1,42 @@
+/**
+ * This module adds PubCommonId to the User ID module
+ * The {@link module:userId} module is required
+ * @module idSystemPubCommonId
+ * @requires module:userId
+ */
+
+import * as utils from '../src/utils.js'
+
+/** @type {Submodule} */
+export const pubCommonIdSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
+  name: 'pubCommonId',
+  /**
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param {string} value
+   * @returns {{pubcid:string}}
+   */
+  decode(value) {
+    return { 'pubcid': value }
+  },
+  /**
+   * performs action to obtain id
+   * @function
+   * @returns {string}
+   */
+  getId() {
+    // If the page includes its own pubcid object, then use that instead.
+    let pubcid;
+    try {
+      if (typeof window['PublisherCommonId'] === 'object') {
+        pubcid = window['PublisherCommonId'].getId();
+      }
+    } catch (e) {}
+    // check pubcid and return if valid was otherwise create a new id
+    return (pubcid) || utils.generateUUID();
+  }
+};

--- a/modules/idSystemUnifiedId.js
+++ b/modules/idSystemUnifiedId.js
@@ -1,0 +1,56 @@
+/**
+ * This module adds UnifiedId to the User ID module
+ * The {@link module:userId} module is required
+ * @module idSystemUnifiedId
+ * @requires module:userId
+ */
+
+import * as utils from '../src/utils.js'
+import {ajax} from '../src/ajax.js';
+import {MODULE_NAME} from './userId.js'
+
+/** @type {Submodule} */
+export const unifiedIdSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
+  name: 'unifiedId',
+  /**
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param {{TDID:string}} value
+   * @returns {{tdid:Object}}
+   */
+  decode(value) {
+    return (value && typeof value['TDID'] === 'string') ? { 'tdid': value['TDID'] } : undefined;
+  },
+  /**
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleParams} [configParams]
+   * @returns {function(callback:function)}
+   */
+  getId(configParams) {
+    if (!configParams || (typeof configParams.partner !== 'string' && typeof configParams.url !== 'string')) {
+      utils.logError(`${MODULE_NAME} - unifiedId submodule requires either partner or url to be defined`);
+      return;
+    }
+    // use protocol relative urls for http or https
+    const url = configParams.url || `//match.adsrvr.org/track/rid?ttd_pid=${configParams.partner}&fmt=json`;
+
+    return function (callback) {
+      ajax(url, response => {
+        let responseObj;
+        if (response) {
+          try {
+            responseObj = JSON.parse(response);
+          } catch (error) {
+            utils.logError(error);
+          }
+        }
+        callback(responseObj);
+      }, undefined, { method: 'GET' });
+    }
+  }
+};

--- a/modules/userId.js
+++ b/modules/userId.js
@@ -1,39 +1,39 @@
 /**
  * This module adds User ID support to prebid.js
+ * @module userId
  */
-import {ajax} from '../src/ajax.js';
-import {config} from '../src/config.js';
-import events from '../src/events.js';
-import * as utils from '../src/utils.js';
-import find from 'core-js/library/fn/array/find';
-import {gdprDataHandler} from '../src/adapterManager.js';
 
-const CONSTANTS = require('../src/constants.json');
+/**
+ * @typedef {Object} ConsentData
+ * @property {(string|undefined)} consentString
+ * @property {(Object|undefined)} vendorData
+ * @property {(boolean|undefined)} gdprApplies
+ */
 
 /**
  * @typedef {Object} SubmoduleConfig
- * @property {string} name - the User ID submodule name
- * @property {SubmoduleStorage} storage - browser storage config
- * @property {SubmoduleParams} params - params config for use by the submodule.getId function
- * @property {Object} value - all object properties will be appended to the User ID bid data
+ * @property {string} name - the User ID submodule name (used to link submodule with config)
+ * @property {(SubmoduleStorage|undefined)} storage - browser storage config
+ * @property {(SubmoduleParams|undefined)} params - params config for use by the submodule.getId function
+ * @property {(Object|undefined)} value - if not empty, this value is added to bid requests for access in adapters
  */
 
 /**
  * @typedef {Object} SubmoduleStorage
  * @property {string} type - browser storage type (html5 or cookie)
  * @property {string} name - key name to use when saving/reading to local storage or cookies
- * @property {number} expires - time to live for browser cookie
+ * @property {(number|undefined)} expires - time to live for browser cookie
  */
 
 /**
  * @typedef {Object} SubmoduleParams
- * @property {string} partner - partner url param value
- * @property {string} url - webservice request url used to load Id data
+ * @property {(string|undefined)} partner - partner url param value
+ * @property {(string|undefined)} url - webservice request url used to load Id data
  */
 
 /**
  * @typedef {Object} Submodule
- * @property {string} name - submodule and config have matching name prop
+ * @property {string} name - used to link submodule with config
  * @property {decode} decode - decode a stored value for passing to bid requests
  * @property {getId} getId - performs action to obtain id and return a value in the callback's response argument
  */
@@ -41,96 +41,76 @@ const CONSTANTS = require('../src/constants.json');
 /**
  * @callback getId
  * @param {SubmoduleParams} [submoduleConfigParams]
- * @param {Object} [consentData]
- * @returns {(Function|Object|string)}
+ * @param {ConsentData} [consentData]
+ * @returns {(function|Object|string)} - returns id data or a callback, the callback is called on the auction end event
  */
 
 /**
  * @callback decode
- * @param {Object|string} idData
- * @returns {Object}
+ * @param {(Object|string)} value
+ * @returns {(Object|undefined)}
  */
 
 /**
  * @typedef {Object} SubmoduleContainer
  * @property {Submodule} submodule
- * @property {SubmoduleConfig} submoduleConfig
- * @property {Object} idObj - decoded User ID data that will be appended to bids
- * @property {function} callback
+ * @property {SubmoduleConfig} config
+ * @property {(Object|undefined)} idObj - cache decoded id value (this is copied to every adUnit bid)
+ * @property {(function|undefined)} callback - holds reference to submodule.getId() result if it returned a function. Will be set to undefined after callback executes
  */
 
-const MODULE_NAME = 'User ID';
+import find from 'core-js/library/fn/array/find';
+import {config} from '../src/config.js';
+import events from '../src/events.js';
+import * as utils from '../src/utils.js';
+import {getGlobal} from '../src/prebidGlobal.js';
+import {gdprDataHandler} from '../src/adapterManager.js';
+import {unifiedIdSubmodule} from './idSystemUnifiedId.js';
+import {pubCommonIdSubmodule} from './idSystemPubCommonId.js';
+import CONSTANTS from '../src/constants.json';
+
+export const MODULE_NAME = 'User ID';
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
 const DEFAULT_SYNC_DELAY = 500;
 
-// @type {number} delay after auction to make webrequests for id data
+/**
+ * delay after auction to make webrequests for id data
+ * @type {number}
+ */
 export let syncDelay;
 
-// @type {SubmoduleContainer[]}
-export let submodules;
+/** @type {SubmoduleContainer[]} */
+export let submodules = [];
 
-// @type {SubmoduleContainer[]}
+/** @type {Submodule[]} */
+let submoduleRegistry = [];
+
+/** @type {SubmoduleContainer[]} */
 let initializedSubmodules;
 
-// @type {Submodule}
-export const unifiedIdSubmodule = {
-  name: 'unifiedId',
-  decode(value) {
-    return (value && typeof value['TDID'] === 'string') ? { 'tdid': value['TDID'] } : undefined;
-  },
-  getId(submoduleConfigParams, consentData) {
-    if (!submoduleConfigParams || (typeof submoduleConfigParams.partner !== 'string' && typeof submoduleConfigParams.url !== 'string')) {
-      utils.logError(`${MODULE_NAME} - unifiedId submodule requires either partner or url to be defined`);
-      return;
-    }
-    const url = submoduleConfigParams.url || `http://match.adsrvr.org/track/rid?ttd_pid=${submoduleConfigParams.partner}&fmt=json`;
+/** @type {SubmoduleConfig[]} */
+let configRegistry;
 
-    return function (callback) {
-      ajax(url, response => {
-        let responseObj;
-        if (response) {
-          try {
-            responseObj = JSON.parse(response);
-          } catch (error) {
-            utils.logError(error);
-          }
-        }
-        callback(responseObj);
-      }, undefined, { method: 'GET' });
-    }
-  }
-};
+/** @type {string[]} */
+let activeStorageTypes = [];
 
-// @type {Submodule}
-export const pubCommonIdSubmodule = {
-  name: 'pubCommonId',
-  decode(value) {
-    return {
-      'pubcid': value
-    }
-  },
-  getId() {
-    // If the page includes its own pubcid object, then use that instead.
-    let pubcid;
-    try {
-      if (typeof window['PublisherCommonId'] === 'object') {
-        pubcid = window['PublisherCommonId'].getId();
-      }
-    } catch (e) {}
-    // check pubcid and return if valid was otherwise create a new id
-    return (pubcid) || utils.generateUUID();
-  }
-};
+/** @type {boolean} */
+let addedUserIdHook = false;
+
+/** @param {Submodule[]} submodules */
+export function setEnabledSubmodules(submodules) {
+  submoduleRegistry = submodules;
+}
 
 /**
  * @param {SubmoduleStorage} storage
  * @param {string} value
- * @param {number|string} expires
+ * @param {(number|string)} expires
  */
 export function setStoredValue(storage, value, expires) {
   try {
-    const valueStr = (typeof value === 'object') ? JSON.stringify(value) : value;
+    const valueStr = utils.isPlainObject(value) ? JSON.stringify(value) : value;
     const expiresStr = (new Date(Date.now() + (expires * (60 * 60 * 24 * 1000)))).toUTCString();
 
     if (storage.type === COOKIE) {
@@ -177,7 +157,7 @@ export function getStoredValue(storage) {
 
 /**
  * test if consent module is present, applies, and is valid for local storage or cookies (purpose 1)
- * @param {Object} consentData
+ * @param {ConsentData} consentData
  * @returns {boolean}
  */
 export function hasGDPRConsent(consentData) {
@@ -193,7 +173,7 @@ export function hasGDPRConsent(consentData) {
 }
 
 /**
- * @param {Object[]} submodules
+ * @param {SubmoduleContainer[]} submodules
  */
 export function processSubmoduleCallbacks(submodules) {
   submodules.forEach(function(submodule) {
@@ -215,25 +195,28 @@ export function processSubmoduleCallbacks(submodules) {
 }
 
 /**
- * @param {Object[]} adUnits
- * @param {Object[]} submodules
+ * @param {AdUnit[]} adUnits
+ * @param {SubmoduleContainer[]} submodules
  */
 export function addIdDataToAdUnitBids(adUnits, submodules) {
-  const submodulesWithIds = submodules.filter(item => typeof item.idObj === 'object' && item.idObj !== null);
-  if (submodulesWithIds.length) {
-    if (adUnits) {
-      adUnits.forEach(adUnit => {
-        adUnit.bids.forEach(bid => {
-          // append the User ID property to bid
-          bid.userId = submodulesWithIds.reduce((carry, item) => {
-            Object.keys(item.idObj).forEach(key => {
-              carry[key] = item.idObj[key];
-            });
-            return carry;
-          }, {});
-        });
+  if (!Array.isArray(adUnits)) {
+    return;
+  }
+
+  const combinedSubmoduleIds = submodules.filter(submodule => !!submodule.idObj).reduce((carry, submodule) => {
+    Object.keys(submodule.idObj).forEach(key => {
+      carry[key] = submodule.idObj[key];
+    });
+    return carry;
+  }, {});
+
+  if (Object.keys(combinedSubmoduleIds).length) {
+    adUnits.forEach(adUnit => {
+      adUnit.bids.forEach(bid => {
+        // create a User ID object on the bid, with child properties from submmodules.idObj
+        bid.userId = combinedSubmoduleIds;
       });
-    }
+    });
   }
 }
 
@@ -243,7 +226,7 @@ export function addIdDataToAdUnitBids(adUnits, submodules) {
  * The two main actions handled by the hook are:
  * 1. check gdpr consentData and handle submodule initialization.
  * 2. append user id data (loaded from cookied/html or from the getId method) to bids to be accessed in adapters.
- * @param {object} reqBidsConfigObj required; This is the same param that's used in pbjs.requestBids.
+ * @param {Object} reqBidsConfigObj required; This is the same param that's used in pbjs.requestBids.
  * @param {function} fn required; The next function in the chain, used by hook.js
  */
 export function requestBidsHook(fn, reqBidsConfigObj) {
@@ -252,7 +235,7 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
     initializedSubmodules = initSubmodules(submodules, gdprDataHandler.getConsentData());
     if (initializedSubmodules.length) {
       // list of sumodules that have callbacks that need to be executed
-      const submodulesWithCallbacks = initializedSubmodules.filter(item => typeof item.callback === 'function');
+      const submodulesWithCallbacks = initializedSubmodules.filter(item => utils.isFn(item.callback));
 
       if (submodulesWithCallbacks.length) {
         // wait for auction complete before processing submodule callbacks
@@ -273,16 +256,16 @@ export function requestBidsHook(fn, reqBidsConfigObj) {
   }
 
   // pass available user id data to bid adapters
-  addIdDataToAdUnitBids(reqBidsConfigObj.adUnits || $$PREBID_GLOBAL$$.adUnits, initializedSubmodules);
+  addIdDataToAdUnitBids(reqBidsConfigObj.adUnits || getGlobal().adUnits, initializedSubmodules);
 
   // calling fn allows prebid to continue processing
   return fn.call(this, reqBidsConfigObj);
 }
 
 /**
- * @param {Object[]} submodules
- * @param {Object} consentData
- * @returns {string[]} initialized submodules
+ * @param {SubmoduleContainer[]} submodules
+ * @param {ConsentData} consentData
+ * @returns {SubmoduleContainer[]} initialized submodules
  */
 export function initSubmodules(submodules, consentData) {
   // gdpr consent with purpose one is required, otherwise exit immediately
@@ -290,36 +273,36 @@ export function initSubmodules(submodules, consentData) {
     utils.logWarn(`${MODULE_NAME} - gdpr permission not valid for local storage or cookies, exit module`);
     return [];
   }
-  return submodules.reduce((carry, item) => {
+  return submodules.reduce((carry, submodule) => {
     // There are two submodule configuration types to handle: storage or value
     // 1. storage: retrieve user id data from cookie/html storage or with the submodule's getId method
     // 2. value: pass directly to bids
-    if (item.config && item.config.storage) {
-      const storedId = getStoredValue(item.config.storage);
+    if (submodule.config && submodule.config.storage) {
+      const storedId = getStoredValue(submodule.config.storage);
       if (storedId) {
         // cache decoded value (this is copied to every adUnit bid)
-        item.idObj = item.submodule.decode(storedId);
+        submodule.idObj = submodule.submodule.decode(storedId);
       } else {
         // getId will return user id data or a function that will load the data
-        const getIdResult = item.submodule.getId(item.config.params, consentData);
+        const getIdResult = submodule.submodule.getId(submodule.config.params, consentData);
 
         // If the getId result has a type of function, it is asynchronous and cannot be called until later
-        if (typeof getIdResult === 'function') {
-          item.callback = getIdResult;
+        if (utils.isFn(getIdResult)) {
+          submodule.callback = getIdResult;
         } else {
           // A getId result that is not a function is assumed to be valid user id data, which should be saved to users local storage or cookies
-          setStoredValue(item.config.storage, getIdResult, item.config.storage.expires);
+          setStoredValue(submodule.config.storage, getIdResult, submodule.config.storage.expires);
 
           // cache decoded value (this is copied to every adUnit bid)
-          item.idObj = item.submodule.decode(getIdResult);
+          submodule.idObj = submodule.submodule.decode(getIdResult);
         }
       }
-    } else if (item.config.value) {
+    } else if (submodule.config.value) {
       // cache decoded value (this is copied to every adUnit bid)
-      item.idObj = item.config.value;
+      submodule.idObj = submodule.config.value;
     }
 
-    carry.push(item);
+    carry.push(submodule);
     return carry;
   }, []);
 }
@@ -328,102 +311,114 @@ export function initSubmodules(submodules, consentData) {
  * list of submodule configurations with valid 'storage' or 'value' obj definitions
  * * storage config: contains values for storing/retrieving User ID data in browser storage
  * * value config: object properties that are copied to bids (without saving to storage)
- * @param {SubmoduleConfig[]} submoduleConfigs
- * @param {Submodule[]} enabledSubmodules
+ * @param {SubmoduleConfig[]} configRegistry
+ * @param {Submodule[]} submoduleRegistry
+ * @param {string[]} activeStorageTypes
  * @returns {SubmoduleConfig[]}
  */
-export function getValidSubmoduleConfigs(submoduleConfigs, enabledSubmodules) {
-  if (!Array.isArray(submoduleConfigs)) {
+export function getValidSubmoduleConfigs(configRegistry, submoduleRegistry, activeStorageTypes) {
+  if (!Array.isArray(configRegistry)) {
     return [];
   }
-
-  // list of browser enabled storage types
-  const validStorageTypes = [];
-  if (utils.localStorageIsEnabled()) {
-    // check if optout exists in local storage (null if returned if key does not exist)
-    if (!localStorage.getItem('_pbjs_id_optout') && !localStorage.getItem('_pubcid_optout')) {
-      validStorageTypes.push(LOCAL_STORAGE);
-    } else {
-      utils.logInfo(`${MODULE_NAME} - opt-out localStorage found, exit module`);
-    }
-  }
-  if (utils.cookiesAreEnabled()) {
-    validStorageTypes.push(COOKIE);
-  }
-
-  return submoduleConfigs.reduce((carry, submoduleConfig) => {
+  return configRegistry.reduce((carry, conf) => {
     // every submodule config obj must contain a valid 'name'
-    if (!submoduleConfig || typeof submoduleConfig.name !== 'string' || !submoduleConfig.name) {
+    if (!conf || utils.isEmptyStr(conf.name)) {
       return carry;
     }
-
-    // Validate storage config
-    // contains 'type' and 'name' properties with non-empty string values
+    // alidate storage config contains 'type' and 'name' properties with non-empty string values
     // 'type' must be a value currently enabled in the browser
-    if (submoduleConfig.storage &&
-      typeof submoduleConfig.storage.type === 'string' && submoduleConfig.storage.type &&
-      typeof submoduleConfig.storage.name === 'string' && submoduleConfig.storage.name &&
-      validStorageTypes.indexOf(submoduleConfig.storage.type) !== -1) {
-      carry.push(submoduleConfig);
-    } else if (submoduleConfig.value !== null && typeof submoduleConfig.value === 'object') {
-      // Validate value config
-      // must be valid object with at least one property
-      carry.push(submoduleConfig);
+    if (conf.storage &&
+      !utils.isEmptyStr(conf.storage.type) &&
+      !utils.isEmptyStr(conf.storage.name) &&
+      activeStorageTypes.indexOf(conf.storage.type) !== -1) {
+      carry.push(conf);
+    } else if (utils.isPlainObject(conf.value)) {
+      carry.push(conf);
     }
     return carry;
   }, []);
 }
 
 /**
- * @param config
- * @param {Submodule[]} enabledSubmodules
+ * update submodules by validating against existing configs and storage types
  */
-export function init (config, enabledSubmodules) {
+function updateSubmodules () {
+  const configs = getValidSubmoduleConfigs(configRegistry, submoduleRegistry, activeStorageTypes);
+  if (!configs.length) {
+    return;
+  }
+  // do this to avoid reprocessing submodules
+  const addedSubmodules = submoduleRegistry.filter(i => !find(submodules, j => j.name === i.name));
+  submodules = addedSubmodules.map(submodule => {
+    // find submodule configuration with matching name, if one exists, append a submoduleContainer with the submodule and config
+    const conf = find(configs, i => i.name === submodule.name);
+    return conf ? {
+      submodule: submodule,
+      config: conf,
+      callback: undefined,
+      idObj: undefined
+    } : null;
+  }).filter(submodule => submodule);
+
+  // initialization if submodules exist
+  if (submodules.length && !addedUserIdHook) {
+    // priority has been set so it loads after consentManagement (which has a priority of 50)
+    getGlobal().requestBids.before(requestBidsHook, 40);
+    utils.logInfo(`${MODULE_NAME} - usersync config updated for ${submodules.length} submodules`);
+    addedUserIdHook = true;
+  }
+}
+
+/**
+ * @param {PrebidConfig} config
+ */
+export function init(config) {
   submodules = [];
+  configRegistry = [];
+  addedUserIdHook = false;
   initializedSubmodules = undefined;
 
-  // exit immediately if opt out cookie exists. _pubcid_optout is checked for compatiblility with pubCommonId module opt out
-  if (utils.getCookie('_pbjs_id_optout')) {
+  // list of browser enabled storage types
+  activeStorageTypes = [
+    utils.localStorageIsEnabled() ? LOCAL_STORAGE : null,
+    utils.cookiesAreEnabled() ? COOKIE : null
+  ].filter(i => i !== null);
+
+  // exit immediately if opt out cookie or local storage keys exists.
+  // _pubcid_optout is checked for compatiblility with pubCommonId
+  if (activeStorageTypes.indexOf(COOKIE) !== -1 && utils.getCookie('_pbjs_id_optout')) {
     utils.logInfo(`${MODULE_NAME} - opt-out cookie found, exit module`);
+    return;
+  }
+  if (activeStorageTypes.indexOf(LOCAL_STORAGE) !== -1 &&
+    (localStorage.getItem('_pbjs_id_optout') && localStorage.getItem('_pubcid_optout'))) {
+    utils.logInfo(`${MODULE_NAME} - opt-out localStorage found, exit module`);
     return;
   }
 
   // listen for config userSyncs to be set
-  config.getConfig('usersync', ({usersync}) => {
-    if (usersync) {
-      syncDelay = (typeof usersync.syncDelay !== 'undefined') ? usersync.syncDelay : DEFAULT_SYNC_DELAY;
-
-      // filter any invalid configs out
-      const submoduleConfigs = getValidSubmoduleConfigs(usersync.userIds, enabledSubmodules);
-      if (submoduleConfigs.length === 0) {
-        // exit module, if no valid configurations exist
-        return;
-      }
-
-      // get list of submodules with valid configurations
-      submodules = enabledSubmodules.reduce((carry, enabledSubmodule) => {
-        // try to find submodule configuration for submodule, if config exists it should be enabled
-        const submoduleConfig = find(submoduleConfigs, item => item.name === enabledSubmodule.name);
-
-        if (submoduleConfig) {
-          // append {SubmoduleContainer} containing the submodule and config
-          carry.push({
-            submodule: enabledSubmodule,
-            config: submoduleConfig,
-            idObj: undefined
-          });
-        }
-        return carry;
-      }, []);
-
-      // complete initialization if any submodules exist
-      if (submodules.length) {
-        // priority has been set so it loads after consentManagement (which has a priority of 50)
-        $$PREBID_GLOBAL$$.requestBids.before(requestBidsHook, 40);
-        utils.logInfo(`${MODULE_NAME} - usersync config updated for ${submodules.length} submodules`);
-      }
+  config.getConfig(conf => {
+    const userSync = conf.userSync || conf.usersync;
+    if (userSync && userSync.userIds) {
+      configRegistry = userSync.userIds || [];
+      syncDelay = utils.isNumber(userSync.syncDelay) ? userSync.syncDelay : DEFAULT_SYNC_DELAY;
+      updateSubmodules();
     }
-  });
+  })
 }
 
-init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+/**
+ * @param {Submodule} submodule
+ */
+export function attachIdSystem(submodule) {
+  if (!find(submoduleRegistry, i => i.name === submodule.name)) {
+    submoduleRegistry.push(submodule);
+    updateSubmodules();
+  }
+}
+
+// Attach submodules
+attachIdSystem(unifiedIdSubmodule);
+attachIdSystem(pubCommonIdSubmodule);
+// init config update listener to start the application
+init(config);

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -1,12 +1,13 @@
 import {
   init,
   syncDelay,
-  pubCommonIdSubmodule,
-  unifiedIdSubmodule,
-  requestBidsHook
+  requestBidsHook,
+  setEnabledSubmodules,
 } from 'modules/userId';
 import {config} from 'src/config';
 import * as utils from 'src/utils';
+import {unifiedIdSubmodule} from 'modules/idSystemUnifiedId';
+import {pubCommonIdSubmodule} from 'modules/idSystemPubCommonId';
 
 let assert = require('chai').assert;
 let expect = require('chai').expect;
@@ -29,6 +30,8 @@ describe('User ID', function() {
 
   before(function() {
     utils.setCookie('_pubcid_optout', '', EXPIRED_COOKIE_DATE);
+    localStorage.removeItem('_pbjs_id_optout');
+    localStorage.removeItem('_pubcid_optout');
   });
 
   describe('Decorate Ad Units', function() {
@@ -56,7 +59,8 @@ describe('User ID', function() {
       let pubcid = utils.getCookie('pubcid');
       expect(pubcid).to.be.null; // there should be no cookie initially
 
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({ usersync: { syncDelay: 0, userIds: [ createStorageConfig() ] } });
 
       requestBidsHook(config => { innerAdUnits1 = config.adUnits }, {adUnits: adUnits1});
@@ -81,7 +85,8 @@ describe('User ID', function() {
       let pubcid1;
       let pubcid2;
 
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({ usersync: { syncDelay: 0, userIds: [ createStorageConfig() ] } });
       requestBidsHook((config) => { innerAdUnits1 = config.adUnits }, {adUnits: adUnits1});
       pubcid1 = utils.getCookie('pubcid'); // get first cookie
@@ -94,7 +99,8 @@ describe('User ID', function() {
         });
       });
 
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({ usersync: { syncDelay: 0, userIds: [ createStorageConfig() ] } });
       requestBidsHook((config) => { innerAdUnits2 = config.adUnits }, {adUnits: adUnits2});
 
@@ -114,7 +120,8 @@ describe('User ID', function() {
       let adUnits = [createAdUnit()];
       let innerAdUnits;
 
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           syncDelay: 0,
@@ -152,13 +159,15 @@ describe('User ID', function() {
     });
 
     it('fails initialization if opt out cookie exists', function () {
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({ usersync: { syncDelay: 0, userIds: [ createStorageConfig() ] } });
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('User ID - opt-out cookie found, exit module');
     });
 
     it('initializes if no opt out cookie exists', function () {
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({ usersync: { syncDelay: 0, userIds: [ createStorageConfig() ] } });
       expect(utils.logInfo.args[0][0]).to.exist.and.to.equal('User ID - usersync config updated for 1 submodules');
     });
@@ -176,20 +185,23 @@ describe('User ID', function() {
     });
 
     it('handles config with no usersync object', function () {
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({});
       // usersync is undefined, and no logInfo message for 'User ID - usersync config updated'
       expect(typeof utils.logInfo.args[0]).to.equal('undefined');
     });
 
     it('handles config with empty usersync object', function () {
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({ usersync: {} });
       expect(typeof utils.logInfo.args[0]).to.equal('undefined');
     });
 
     it('handles config with usersync and userIds that are empty objs', function () {
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           userIds: [{}]
@@ -199,7 +211,8 @@ describe('User ID', function() {
     });
 
     it('handles config with usersync and userIds with empty names or that dont match a submodule.name', function () {
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           userIds: [{
@@ -215,7 +228,8 @@ describe('User ID', function() {
     });
 
     it('config with 1 configurations should create 1 submodules', function () {
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           syncDelay: 0,
@@ -229,7 +243,8 @@ describe('User ID', function() {
     });
 
     it('config with 2 configurations should result in 2 submodules add', function () {
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           syncDelay: 0,
@@ -245,7 +260,8 @@ describe('User ID', function() {
     });
 
     it('config syncDelay updates module correctly', function () {
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           syncDelay: 99,
@@ -269,7 +285,8 @@ describe('User ID', function() {
     it('test hook from pubcommonid cookie', function(done) {
       utils.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 100000).toUTCString()));
 
-      init(config, [pubCommonIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           syncDelay: 0,
@@ -290,7 +307,8 @@ describe('User ID', function() {
     });
 
     it('test hook from pubcommonid config value object', function(done) {
-      init(config, [pubCommonIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           syncDelay: 0,
@@ -316,7 +334,8 @@ describe('User ID', function() {
       localStorage.setItem('unifiedid_alt', JSON.stringify({'TDID': 'testunifiedid_alt'}));
       localStorage.setItem('unifiedid_alt_exp', '');
 
-      init(config, [unifiedIdSubmodule]);
+      setEnabledSubmodules([unifiedIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           syncDelay: 0,
@@ -340,7 +359,8 @@ describe('User ID', function() {
       utils.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 5000).toUTCString()));
       utils.setCookie('unifiedid', JSON.stringify({'TDID': 'testunifiedid'}), (new Date(Date.now() + 5000).toUTCString()));
 
-      init(config, [pubCommonIdSubmodule, unifiedIdSubmodule]);
+      setEnabledSubmodules([pubCommonIdSubmodule, unifiedIdSubmodule]);
+      init(config);
       config.setConfig({
         usersync: {
           syncDelay: 0,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
- [X] Other

## Description of change
- Support external userId sub-modules. 
PBJS userId sub-modules are refactored as separate files.
**Digitrust** module is refactored into a separate file that automatically includes userId when brought in through gulp
- Fix `unifiedId` HTTPS support. 
[issue 3796](https://github.com/prebid/Prebid.js/issues/3796)
- Fix allow camelcase `userSync` and lowercase `usersync`,  
The plan is to support both `usersync` and `userSync` until Prebid.js 3.0, and then `usersync` will be deprecated.
[issue 3818](https://github.com/prebid/Prebid.js/issues/3818)

## Related to
[HB-4592: Support external userId sub-modules](https://jira.rubiconproject.com/browse/HB-4592)
[HB-4638: Allow camelcase userSync](https://jira.rubiconproject.com/browse/HB-4638)
[HB-4611: UserId module HTTPS support](https://jira.rubiconproject.com/browse/HB-4611)
