### PR TITLE
PBJS RP analytics adapter: convert to 3.0

### DIFF
--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -1,0 +1,484 @@
+import adapter from '../src/AnalyticsAdapter';
+import adapterManager from '../src/adapterManager';
+import CONSTANTS from '../src/constants.json';
+import { ajax } from '../src/ajax';
+import { config } from '../src/config';
+import * as utils from '../src/utils';
+
+const {
+  EVENTS: {
+    AUCTION_INIT,
+    AUCTION_END,
+    BID_REQUESTED,
+    BID_RESPONSE,
+    BIDDER_DONE,
+    BID_TIMEOUT,
+    BID_WON,
+    SET_TARGETING
+  },
+  STATUS: {
+    GOOD,
+    NO_BID
+  }
+} = CONSTANTS;
+
+let serverConfig;
+config.getConfig('s2sConfig', ({s2sConfig}) => {
+  serverConfig = s2sConfig;
+});
+
+export const SEND_TIMEOUT = 3000;
+const DEFAULT_INTEGRATION = 'pbjs';
+
+const cache = {
+  auctions: {},
+  targeting: {},
+  timeouts: {},
+};
+
+function stringProperties(obj) {
+  return Object.keys(obj).reduce((newObj, prop) => {
+    let value = obj[prop];
+    if (typeof value === 'number') {
+      value = value.toFixed(3);
+    } else if (typeof value !== 'string') {
+      value = String(value);
+    }
+    newObj[prop] = value;
+    return newObj;
+  }, {});
+}
+
+function sizeToDimensions(size) {
+  return {
+    width: size.w || size[0],
+    height: size.h || size[1]
+  };
+}
+
+function validMediaType(type) {
+  return ['banner', 'native', 'video'].indexOf(type) !== -1;
+}
+
+function formatSource(src) {
+  if (typeof src === 'undefined') {
+    src = 'client';
+  } else if (src === 's2s') {
+    src = 'server';
+  }
+  return src.toLowerCase();
+}
+
+function sendMessage(auctionId, bidWonId) {
+  function formatBid(bid) {
+    return utils.pick(bid, [
+      'bidder',
+      'bidId', bidId => utils.deepAccess(bid, 'bidResponse.seatBidId') || bidId,
+      'status',
+      'error',
+      'source', (source, bid) => {
+        if (source) {
+          return source;
+        }
+        return serverConfig && Array.isArray(serverConfig.bidders) && serverConfig.bidders.indexOf(bid.bidder) !== -1
+          ? 'server' : 'client'
+      },
+      'clientLatencyMillis',
+      'serverLatencyMillis',
+      'params',
+      'bidResponse', bidResponse => bidResponse ? utils.pick(bidResponse, [
+        'bidPriceUSD',
+        'dealId',
+        'dimensions',
+        'mediaType'
+      ]) : undefined
+    ]);
+  }
+  function formatBidWon(bid) {
+    return Object.assign(formatBid(bid), utils.pick(bid.adUnit, [
+      'adUnitCode',
+      'transactionId',
+      'videoAdFormat', () => bid.videoAdFormat,
+      'mediaTypes'
+    ]), {
+      adserverTargeting: stringProperties(cache.targeting[bid.adUnit.adUnitCode] || {}),
+      bidwonStatus: 'success', // hard-coded for now
+      accountId,
+      siteId: bid.siteId,
+      zoneId: bid.zoneId,
+      samplingFactor
+    });
+  }
+  let auctionCache = cache.auctions[auctionId];
+  let referrer = config.getConfig('pageUrl') || auctionCache.referrer;
+  let message = {
+    eventTimeMillis: Date.now(),
+    integration: config.getConfig('rubicon.int_type') || DEFAULT_INTEGRATION,
+    version: '$prebid.version$',
+    referrerUri: referrer
+  };
+  const wrapperName = config.getConfig('rubicon.wrapperName');
+  if (wrapperName) {
+    message.wrapperName = wrapperName;
+  }
+  if (auctionCache && !auctionCache.sent) {
+    let adUnitMap = Object.keys(auctionCache.bids).reduce((adUnits, bidId) => {
+      let bid = auctionCache.bids[bidId];
+      let adUnit = adUnits[bid.adUnit.adUnitCode];
+      if (!adUnit) {
+        adUnit = adUnits[bid.adUnit.adUnitCode] = utils.pick(bid.adUnit, [
+          'adUnitCode',
+          'transactionId',
+          'mediaTypes',
+          'dimensions',
+          'adserverTargeting', () => stringProperties(cache.targeting[bid.adUnit.adUnitCode] || {})
+        ]);
+        adUnit.bids = [];
+      }
+
+      // Add site and zone id if not there and if we found a rubicon bidder
+      if ((!adUnit.siteId || !adUnit.zoneId) && rubiconAliases.indexOf(bid.bidder) !== -1) {
+        if (utils.deepAccess(bid, 'params.accountId') == accountId) {
+          adUnit.accountId = parseInt(accountId);
+          adUnit.siteId = parseInt(utils.deepAccess(bid, 'params.siteId'));
+          adUnit.zoneId = parseInt(utils.deepAccess(bid, 'params.zoneId'));
+        }
+      }
+
+      if (bid.videoAdFormat && !adUnit.videoAdFormat) {
+        adUnit.videoAdFormat = bid.videoAdFormat;
+      }
+
+      // determine adUnit.status from its bid statuses.  Use priority below to determine, higher index is better
+      let statusPriority = ['error', 'no-bid', 'success'];
+      if (statusPriority.indexOf(bid.status) > statusPriority.indexOf(adUnit.status)) {
+        adUnit.status = bid.status;
+      }
+
+      adUnit.bids.push(formatBid(bid));
+
+      return adUnits;
+    }, {});
+
+    // We need to mark each cached bid response with its appropriate rubicon site-zone id
+    // This allows the bidWon events to have these params even in the case of a delayed render
+    Object.keys(auctionCache.bids).forEach(function (bidId) {
+      let adCode = auctionCache.bids[bidId].adUnit.adUnitCode;
+      Object.assign(auctionCache.bids[bidId], utils.pick(adUnitMap[adCode], ['accountId', 'siteId', 'zoneId']));
+    });
+
+    let auction = {
+      clientTimeoutMillis: auctionCache.timeout,
+      samplingFactor,
+      accountId,
+      adUnits: Object.keys(adUnitMap).map(i => adUnitMap[i])
+    };
+
+    if (serverConfig) {
+      auction.serverTimeoutMillis = serverConfig.timeout;
+    }
+
+    message.auctions = [auction];
+
+    let bidsWon = Object.keys(auctionCache.bidsWon).reduce((memo, adUnitCode) => {
+      let bidId = auctionCache.bidsWon[adUnitCode];
+      if (bidId) {
+        memo.push(formatBidWon(auctionCache.bids[bidId]));
+      }
+      return memo;
+    }, []);
+
+    if (bidsWon.length > 0) {
+      message.bidsWon = bidsWon;
+    }
+
+    auctionCache.sent = true;
+  } else if (bidWonId && auctionCache && auctionCache.bids[bidWonId]) {
+    message.bidsWon = [
+      formatBidWon(auctionCache.bids[bidWonId])
+    ];
+  }
+
+  ajax(
+    this.getUrl(),
+    null,
+    JSON.stringify(message),
+    {
+      contentType: 'application/json'
+    }
+  );
+}
+
+function getBidPrice(bid) {
+  if (typeof bid.currency === 'string' && bid.currency.toUpperCase() === 'USD') {
+    return Number(bid.cpm);
+  }
+  // use currency conversion function if present
+  if (typeof bid.getCpmInNewCurrency === 'function') {
+    return Number(bid.getCpmInNewCurrency('USD'));
+  }
+  utils.logWarn('Rubicon Analytics Adapter: Could not determine the bidPriceUSD of the bid ', bid);
+}
+
+export function parseBidResponse(bid, previousBidResponse) {
+  // The current bidResponse for this matching requestId/bidRequestId
+  let responsePrice = getBidPrice(bid)
+  // we need to compare it with the previous one (if there was one)
+  if (previousBidResponse && previousBidResponse.bidPriceUSD > responsePrice) {
+    return previousBidResponse;
+  }
+  return utils.pick(bid, [
+    'bidPriceUSD', () => responsePrice,
+    'dealId',
+    'status',
+    'mediaType',
+    'dimensions', () => utils.pick(bid, [
+      'width',
+      'height'
+    ]),
+    'seatBidId',
+  ]);
+}
+
+let samplingFactor = 1;
+let accountId;
+// List of known rubicon aliases
+// This gets updated on auction init to account for any custom aliases present
+let rubiconAliases = ['rubicon'];
+
+/*
+  Checks the alias registry for any entries of the rubicon bid adapter.
+  adds to the rubiconAliases list if found
+*/
+function setRubiconAliases(aliasRegistry) {
+  Object.keys(aliasRegistry).forEach(function (alias) {
+    if (aliasRegistry[alias] === 'rubicon') {
+      rubiconAliases.push(alias);
+    }
+  });
+}
+
+let baseAdapter = adapter({analyticsType: 'endpoint'});
+let rubiconAdapter = Object.assign({}, baseAdapter, {
+  enableAnalytics(config = {}) {
+    let error = false;
+    samplingFactor = 1;
+
+    if (typeof config.options === 'object') {
+      if (config.options.accountId) {
+        accountId = Number(config.options.accountId);
+      }
+      if (config.options.endpoint) {
+        this.getUrl = () => config.options.endpoint;
+      } else {
+        utils.logError('required endpoint missing from rubicon analytics');
+        error = true;
+      }
+      if (typeof config.options.sampling !== 'undefined') {
+        samplingFactor = 1 / parseFloat(config.options.sampling);
+      }
+      if (typeof config.options.samplingFactor !== 'undefined') {
+        if (typeof config.options.sampling !== 'undefined') {
+          utils.logWarn('Both options.samplingFactor and options.sampling enabled in rubicon analytics, defaulting to samplingFactor');
+        }
+        samplingFactor = parseFloat(config.options.samplingFactor);
+        config.options.sampling = 1 / samplingFactor;
+      }
+    }
+
+    let validSamplingFactors = [1, 10, 20, 40, 100];
+    if (validSamplingFactors.indexOf(samplingFactor) === -1) {
+      error = true;
+      utils.logError('invalid samplingFactor for rubicon analytics: ' + samplingFactor + ', must be one of ' + validSamplingFactors.join(', '));
+    } else if (!accountId) {
+      error = true;
+      utils.logError('required accountId missing for rubicon analytics');
+    }
+
+    if (!error) {
+      baseAdapter.enableAnalytics.call(this, config);
+    }
+  },
+  disableAnalytics() {
+    this.getUrl = baseAdapter.getUrl;
+    accountId = null;
+    baseAdapter.disableAnalytics.apply(this, arguments);
+  },
+  track({eventType, args}) {
+    switch (eventType) {
+      case AUCTION_INIT:
+        // set the rubicon aliases
+        setRubiconAliases(adapterManager.aliasRegistry);
+        let cacheEntry = utils.pick(args, [
+          'timestamp',
+          'timeout'
+        ]);
+        cacheEntry.bids = {};
+        cacheEntry.bidsWon = {};
+        cache.auctions[args.auctionId] = cacheEntry;
+        break;
+      case BID_REQUESTED:
+        cache.auctions[args.auctionId].referrer = args.refererInfo.referer;
+        Object.assign(cache.auctions[args.auctionId].bids, args.bids.reduce((memo, bid) => {
+          // mark adUnits we expect bidWon events for
+          cache.auctions[args.auctionId].bidsWon[bid.adUnitCode] = false;
+
+          memo[bid.bidId] = utils.pick(bid, [
+            'bidder', bidder => bidder.toLowerCase(),
+            'bidId',
+            'status', () => 'no-bid', // default a bid to no-bid until response is recieved or bid is timed out
+            'finalSource as source',
+            'params', (params, bid) => {
+              switch (bid.bidder) {
+                // specify bidder params we want here
+                case 'rubicon':
+                  return utils.pick(params, [
+                    'accountId',
+                    'siteId',
+                    'zoneId'
+                  ]);
+              }
+            },
+            'videoAdFormat', (_, cachedBid) => {
+              if (cachedBid.bidder === 'rubicon') {
+                return ({
+                  201: 'pre-roll',
+                  202: 'interstitial',
+                  203: 'outstream',
+                  204: 'mid-roll',
+                  205: 'post-roll',
+                  207: 'vertical'
+                })[utils.deepAccess(bid, 'params.video.size_id')];
+              } else {
+                let startdelay = parseInt(utils.deepAccess(bid, 'params.video.startdelay'), 10);
+                if (!isNaN(startdelay)) {
+                  if (startdelay > 0) {
+                    return 'mid-roll';
+                  }
+                  return ({
+                    '0': 'pre-roll',
+                    '-1': 'mid-roll',
+                    '-2': 'post-roll'
+                  })[startdelay]
+                }
+              }
+            },
+            'adUnit', () => utils.pick(bid, [
+              'adUnitCode',
+              'transactionId',
+              'sizes as dimensions', sizes => sizes.map(sizeToDimensions),
+              'mediaTypes', (types) => {
+                if (bid.mediaType && validMediaType(bid.mediaType)) {
+                  return [bid.mediaType];
+                }
+                if (Array.isArray(types)) {
+                  return types.filter(validMediaType);
+                }
+                if (typeof types === 'object') {
+                  if (!bid.sizes) {
+                    bid.dimensions = [];
+                    utils._each(types, (type) =>
+                      bid.dimensions = bid.dimensions.concat(
+                        type.sizes.map(sizeToDimensions)
+                      )
+                    );
+                  }
+                  return Object.keys(types).filter(validMediaType);
+                }
+                return ['banner'];
+              }
+            ])
+          ]);
+          return memo;
+        }, {}));
+        break;
+      case BID_RESPONSE:
+        let bid = cache.auctions[args.auctionId].bids[args.requestId];
+        if (!bid) {
+          utils.logError('Rubicon Anlytics Adapter Error: Could not find associated bid request for bid response with requestId: ', args.requestId);
+          break;
+        }
+        bid.source = formatSource(bid.source || args.source);
+        switch (args.getStatusCode()) {
+          case GOOD:
+            bid.status = 'success';
+            delete bid.error; // it's possible for this to be set by a previous timeout
+            break;
+          case NO_BID:
+            bid.status = 'no-bid';
+            delete bid.error;
+            break;
+          default:
+            bid.status = 'error';
+            bid.error = {
+              code: 'request-error'
+            };
+        }
+        bid.clientLatencyMillis = Date.now() - cache.auctions[args.auctionId].timestamp;
+        bid.bidResponse = parseBidResponse(args, bid.bidResponse);
+        // RP server banner overwrites bidId with bid.seatBidId
+        if (utils.deepAccess(bid, 'bidResponse.seatBidId') && bid.bidder === 'rubicon' && bid.source === 'server' && ['video', 'banner'].some(i => utils.deepAccess(bid, 'bidResponse.mediaType') === i)) {
+          bid.seatBidId = bid.bidResponse.seatBidId;
+        }
+        break;
+      case BIDDER_DONE:
+        args.bids.forEach(bid => {
+          let cachedBid = cache.auctions[bid.auctionId].bids[bid.bidId || bid.requestId];
+          if (typeof bid.serverResponseTimeMs !== 'undefined') {
+            cachedBid.serverLatencyMillis = bid.serverResponseTimeMs;
+          }
+          if (!cachedBid.status) {
+            cachedBid.status = 'no-bid';
+          }
+          if (!cachedBid.clientLatencyMillis) {
+            cachedBid.clientLatencyMillis = Date.now() - cache.auctions[bid.auctionId].timestamp;
+          }
+        });
+        break;
+      case SET_TARGETING:
+        Object.assign(cache.targeting, args);
+        break;
+      case BID_WON:
+        let auctionCache = cache.auctions[args.auctionId];
+        auctionCache.bidsWon[args.adUnitCode] = args.requestId;
+
+        // check if this BID_WON missed the boat, if so send by itself
+        if (auctionCache.sent === true) {
+          sendMessage.call(this, args.auctionId, args.requestId);
+        } else if (Object.keys(auctionCache.bidsWon).reduce((memo, adUnitCode) => {
+          // only send if we've received bidWon events for all adUnits in auction
+          memo = memo && auctionCache.bidsWon[adUnitCode];
+          return memo;
+        }, true)) {
+          clearTimeout(cache.timeouts[args.auctionId]);
+          delete cache.timeouts[args.auctionId];
+
+          sendMessage.call(this, args.auctionId);
+        }
+        break;
+      case AUCTION_END:
+        // start timer to send batched payload just in case we don't hear any BID_WON events
+        cache.timeouts[args.auctionId] = setTimeout(() => {
+          sendMessage.call(this, args.auctionId);
+        }, SEND_TIMEOUT);
+        break;
+      case BID_TIMEOUT:
+        args.forEach(badBid => {
+          let auctionCache = cache.auctions[badBid.auctionId];
+          let bid = auctionCache.bids[badBid.bidId || badBid.requestId];
+          bid.status = 'error';
+          bid.error = {
+            code: 'timeout-error'
+          };
+        });
+        break;
+    }
+  }
+});
+
+adapterManager.registerAnalyticsAdapter({
+  adapter: rubiconAdapter,
+  code: 'rubicon'
+});
+
+export default rubiconAdapter;

--- a/modules/rubiconAnalyticsAdapter.js
+++ b/modules/rubiconAnalyticsAdapter.js
@@ -315,10 +315,10 @@ let rubiconAdapter = Object.assign({}, baseAdapter, {
         ]);
         cacheEntry.bids = {};
         cacheEntry.bidsWon = {};
+        cacheEntry.referrer = args.bidderRequests[0].refererInfo.referer;
         cache.auctions[args.auctionId] = cacheEntry;
         break;
       case BID_REQUESTED:
-        cache.auctions[args.auctionId].referrer = args.refererInfo.referer;
         Object.assign(cache.auctions[args.auctionId].bids, args.bids.reduce((memo, bid) => {
           // mark adUnits we expect bidWon events for
           cache.auctions[args.auctionId].bidsWon[bid.adUnitCode] = false;

--- a/test/spec/modules/rubiconAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rubiconAnalyticsAdapter_spec.js
@@ -1,0 +1,815 @@
+import rubiconAnalyticsAdapter, { SEND_TIMEOUT, parseBidResponse } from 'modules/rubiconAnalyticsAdapter';
+import CONSTANTS from 'src/constants.json';
+import { config } from 'src/config';
+
+import {
+  setConfig,
+  addBidResponseHook,
+} from 'modules/currency';
+
+let Ajv = require('ajv');
+let schema = require('./rubiconAnalyticsSchema.json');
+let ajv = new Ajv({
+  allErrors: true
+});
+
+let validator = ajv.compile(schema);
+
+function validate(message) {
+  validator(message);
+  expect(validator.errors).to.deep.equal(null);
+}
+
+// using es6 "import * as events from 'src/events'" causes the events.getEvents stub not to work...
+let events = require('src/events');
+let ajax = require('src/ajax');
+let utils = require('src/utils');
+
+const {
+  EVENTS: {
+    AUCTION_INIT,
+    AUCTION_END,
+    BID_REQUESTED,
+    BID_RESPONSE,
+    BIDDER_DONE,
+    BID_WON,
+    BID_TIMEOUT,
+    SET_TARGETING
+  }
+} = CONSTANTS;
+
+const BID = {
+  'bidder': 'rubicon',
+  'width': 640,
+  'height': 480,
+  'mediaType': 'video',
+  'statusMessage': 'Bid available',
+  'bidId': '2ecff0db240757',
+  'adId': 'fake_ad_id',
+  'source': 'client',
+  'requestId': '2ecff0db240757',
+  'currency': 'USD',
+  'creativeId': '3571560',
+  'cpm': 1.22752,
+  'ttl': 300,
+  'netRevenue': false,
+  'ad': '<html></html>',
+  'rubiconTargeting': {
+    'rpfl_elemid': '/19968336/header-bid-tag-0',
+    'rpfl_14062': '2_tier0100'
+  },
+  'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+  'responseTimestamp': 1519149629415,
+  'requestTimestamp': 1519149628471,
+  'adUnitCode': '/19968336/header-bid-tag-0',
+  'timeToRespond': 944,
+  'pbLg': '1.00',
+  'pbMg': '1.20',
+  'pbHg': '1.22',
+  'pbAg': '1.20',
+  'pbDg': '1.22',
+  'pbCg': '',
+  'size': '640x480',
+  'adserverTargeting': {
+    'hb_bidder': 'rubicon',
+    'hb_adid': '2ecff0db240757',
+    'hb_pb': 1.20,
+    'hb_size': '640x480',
+    'hb_source': 'client'
+  },
+  getStatusCode() {
+    return 1;
+  }
+};
+
+const BID2 = Object.assign({}, BID, {
+  adUnitCode: '/19968336/header-bid-tag1',
+  bidId: '3bd4ebb1c900e2',
+  adId: 'fake_ad_id',
+  requestId: '3bd4ebb1c900e2',
+  width: 728,
+  height: 90,
+  mediaType: 'banner',
+  cpm: 1.52,
+  source: 'server',
+  seatBidId: 'aaaa-bbbb-cccc-dddd',
+  rubiconTargeting: {
+    'rpfl_elemid': '/19968336/header-bid-tag1',
+    'rpfl_14062': '2_tier0100'
+  },
+  adserverTargeting: {
+    'hb_bidder': 'rubicon',
+    'hb_adid': '3bd4ebb1c900e2',
+    'hb_pb': '1.500',
+    'hb_size': '728x90',
+    'hb_source': 'server'
+  }
+});
+
+const MOCK = {
+  SET_TARGETING: {
+    [BID.adUnitCode]: BID.adserverTargeting,
+    [BID2.adUnitCode]: BID2.adserverTargeting
+  },
+  AUCTION_INIT: {
+    'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+    'timestamp': 1519767010567,
+    'auctionStatus': 'inProgress',
+    'adUnits': [ {
+      'code': '/19968336/header-bid-tag1',
+      'sizes': [[640, 480]],
+      'bids': [ {
+        'bidder': 'rubicon',
+        'params': {
+          'accountId': 1001, 'siteId': 113932, 'zoneId': 535512
+        }
+      } ],
+      'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014'
+    }
+    ],
+    'adUnitCodes': ['/19968336/header-bid-tag1'],
+    'bidderRequests': [ {
+      'bidderCode': 'rubicon',
+      'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+      'bidderRequestId': '1be65d7958826a',
+      'bids': [ {
+        'bidder': 'rubicon',
+        'params': {
+          'accountId': 1001, 'siteId': 113932, 'zoneId': 535512
+        },
+        'mediaTypes': {
+          'banner': {
+            'sizes': [[640, 480]]
+          }
+        },
+        'adUnitCode': '/19968336/header-bid-tag1',
+        'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+        'sizes': [[640, 480]],
+        'bidId': '2ecff0db240757',
+        'bidderRequestId': '1be65d7958826a',
+        'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+        'src': 'client',
+        'bidRequestsCount': 1
+      }
+      ],
+      'timeout': 3000,
+      'refererInfo': {
+        'referer': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+      }
+    }
+    ],
+    'bidsReceived': [],
+    'winningBids': [],
+    'timeout': 3000,
+    'config': {
+      'accountId': 1001, 'endpoint': '//localhost:9999/event'
+    }
+  },
+  BID_REQUESTED: {
+    'bidder': 'rubicon',
+    'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+    'bidderRequestId': '1be65d7958826a',
+    'bids': [
+      {
+        'bidder': 'rubicon',
+        'params': {
+          'accountId': '1001',
+          'siteId': '70608',
+          'zoneId': '335918',
+          'userId': '12346',
+          'keywords': ['a', 'b', 'c'],
+          'inventory': 'test',
+          'visitor': {'ucat': 'new', 'lastsearch': 'iphone'},
+          'position': 'btf',
+          'video': {
+            'language': 'en',
+            'playerHeight': 480,
+            'playerWidth': 640,
+            'size_id': 203,
+            'skip': 1,
+            'skipdelay': 15,
+            'aeParams': {
+              'p_aso.video.ext.skip': '1',
+              'p_aso.video.ext.skipdelay': '15'
+            }
+          }
+        },
+        'mediaType': 'video',
+        'adUnitCode': '/19968336/header-bid-tag-0',
+        'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+        'sizes': [[640, 480]],
+        'bidId': '2ecff0db240757',
+        'bidderRequestId': '1be65d7958826a',
+        'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa'
+      },
+      {
+        'bidder': 'rubicon',
+        'params': {
+          'accountId': '14062',
+          'siteId': '70608',
+          'zoneId': '335918',
+          'userId': '12346',
+          'keywords': ['a', 'b', 'c'],
+          'inventory': {'rating': '4-star', 'prodtype': 'tech'},
+          'visitor': {'ucat': 'new', 'lastsearch': 'iphone'},
+          'position': 'atf'
+        },
+        'mediaTypes': {
+          'banner': {
+            'sizes': [[1000, 300], [970, 250], [728, 90]]
+          }
+        },
+        'adUnitCode': '/19968336/header-bid-tag1',
+        'transactionId': 'c116413c-9e3f-401a-bee1-d56aec29a1d4',
+        'sizes': [[1000, 300], [970, 250], [728, 90]],
+        'bidId': '3bd4ebb1c900e2',
+        'seatBidId': 'aaaa-bbbb-cccc-dddd',
+        'bidderRequestId': '1be65d7958826a',
+        'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa'
+      }
+    ],
+    'auctionStart': 1519149536560,
+    'timeout': 5000,
+    'start': 1519149562216,
+    'refererInfo': {
+      'referer': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+    }
+  },
+  BID_RESPONSE: [
+    BID,
+    BID2
+  ],
+  AUCTION_END: {
+    'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa'
+  },
+  BID_WON: [
+    Object.assign({}, BID, {
+      'status': 'rendered'
+    }),
+    Object.assign({}, BID2, {
+      'status': 'rendered'
+    })
+  ],
+  BIDDER_DONE: {
+    'bidderCode': 'rubicon',
+    'bids': [
+      BID,
+      Object.assign({}, BID2, {
+        'serverResponseTimeMs': 42,
+      })
+    ]
+  },
+  BID_TIMEOUT: [
+    {
+      'bidId': '2ecff0db240757',
+      'bidder': 'rubicon',
+      'adUnitCode': '/19968336/header-bid-tag-0',
+      'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa'
+    }
+  ]
+};
+
+const ANALYTICS_MESSAGE = {
+  'eventTimeMillis': 1519767013781,
+  'integration': 'pbjs',
+  'version': '$prebid.version$',
+  'referrerUri': 'http://www.test.com/page.html',
+  'auctions': [
+    {
+      'clientTimeoutMillis': 3000,
+      'serverTimeoutMillis': 1000,
+      'accountId': 1001,
+      'samplingFactor': 1,
+      'adUnits': [
+        {
+          'adUnitCode': '/19968336/header-bid-tag-0',
+          'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+          'videoAdFormat': 'outstream',
+          'mediaTypes': [
+            'video'
+          ],
+          'dimensions': [
+            {
+              'width': 640,
+              'height': 480
+            }
+          ],
+          'status': 'success',
+          'accountId': 1001,
+          'siteId': 70608,
+          'zoneId': 335918,
+          'adserverTargeting': {
+            'hb_bidder': 'rubicon',
+            'hb_adid': '2ecff0db240757',
+            'hb_pb': '1.200',
+            'hb_size': '640x480',
+            'hb_source': 'client'
+          },
+          'bids': [
+            {
+              'bidder': 'rubicon',
+              'bidId': '2ecff0db240757',
+              'status': 'success',
+              'source': 'client',
+              'clientLatencyMillis': 3214,
+              'params': {
+                'accountId': '1001',
+                'siteId': '70608',
+                'zoneId': '335918'
+              },
+              'bidResponse': {
+                'bidPriceUSD': 1.22752,
+                'dimensions': {
+                  'width': 640,
+                  'height': 480
+                },
+                'mediaType': 'video'
+              }
+            }
+          ]
+        },
+        {
+          'adUnitCode': '/19968336/header-bid-tag1',
+          'transactionId': 'c116413c-9e3f-401a-bee1-d56aec29a1d4',
+          'mediaTypes': [
+            'banner'
+          ],
+          'dimensions': [
+            {
+              'width': 1000,
+              'height': 300
+            },
+            {
+              'width': 970,
+              'height': 250
+            },
+            {
+              'width': 728,
+              'height': 90
+            }
+          ],
+          'status': 'success',
+          'adserverTargeting': {
+            'hb_bidder': 'rubicon',
+            'hb_adid': '3bd4ebb1c900e2',
+            'hb_pb': '1.500',
+            'hb_size': '728x90',
+            'hb_source': 'server'
+          },
+          'bids': [
+            {
+              'bidder': 'rubicon',
+              'bidId': 'aaaa-bbbb-cccc-dddd',
+              'status': 'success',
+              'source': 'server',
+              'clientLatencyMillis': 3214,
+              'serverLatencyMillis': 42,
+              'params': {
+                'accountId': '14062',
+                'siteId': '70608',
+                'zoneId': '335918'
+              },
+              'bidResponse': {
+                'bidPriceUSD': 1.52,
+                'dimensions': {
+                  'width': 728,
+                  'height': 90
+                },
+                'mediaType': 'banner'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  'bidsWon': [
+    {
+      'bidder': 'rubicon',
+      'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+      'adUnitCode': '/19968336/header-bid-tag-0',
+      'bidId': '2ecff0db240757',
+      'status': 'success',
+      'source': 'client',
+      'clientLatencyMillis': 3214,
+      'samplingFactor': 1,
+      'accountId': 1001,
+      'siteId': 70608,
+      'zoneId': 335918,
+      'params': {
+        'accountId': '1001',
+        'siteId': '70608',
+        'zoneId': '335918'
+      },
+      'videoAdFormat': 'outstream',
+      'mediaTypes': [
+        'video'
+      ],
+      'adserverTargeting': {
+        'hb_bidder': 'rubicon',
+        'hb_adid': '2ecff0db240757',
+        'hb_pb': '1.200',
+        'hb_size': '640x480',
+        'hb_source': 'client'
+      },
+      'bidResponse': {
+        'bidPriceUSD': 1.22752,
+        'dimensions': {
+          'width': 640,
+          'height': 480
+        },
+        'mediaType': 'video'
+      },
+      'bidwonStatus': 'success'
+    },
+    {
+      'bidder': 'rubicon',
+      'transactionId': 'c116413c-9e3f-401a-bee1-d56aec29a1d4',
+      'adUnitCode': '/19968336/header-bid-tag1',
+      'bidId': 'aaaa-bbbb-cccc-dddd',
+      'status': 'success',
+      'source': 'server',
+      'clientLatencyMillis': 3214,
+      'serverLatencyMillis': 42,
+      'samplingFactor': 1,
+      'accountId': 1001,
+      'params': {
+        'accountId': '14062',
+        'siteId': '70608',
+        'zoneId': '335918'
+      },
+      'mediaTypes': [
+        'banner'
+      ],
+      'adserverTargeting': {
+        'hb_bidder': 'rubicon',
+        'hb_adid': '3bd4ebb1c900e2',
+        'hb_pb': '1.500',
+        'hb_size': '728x90',
+        'hb_source': 'server'
+      },
+      'bidResponse': {
+        'bidPriceUSD': 1.52,
+        'dimensions': {
+          'width': 728,
+          'height': 90
+        },
+        'mediaType': 'banner'
+      },
+      'bidwonStatus': 'success'
+    }
+  ],
+  'wrapperName': '10000_fakewrapper_test'
+};
+
+function performStandardAuction() {
+  events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
+  events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
+  events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
+  events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[1]);
+  events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
+  events.emit(AUCTION_END, MOCK.AUCTION_END);
+  events.emit(SET_TARGETING, MOCK.SET_TARGETING);
+  events.emit(BID_WON, MOCK.BID_WON[0]);
+  events.emit(BID_WON, MOCK.BID_WON[1]);
+}
+
+describe('rubicon analytics adapter', function () {
+  let sandbox;
+  let xhr;
+  let requests;
+  let oldScreen;
+  let clock;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+
+    xhr = sandbox.useFakeXMLHttpRequest();
+    requests = [];
+    xhr.onCreate = request => requests.push(request);
+
+    sandbox.stub(events, 'getEvents').returns([]);
+
+    clock = sandbox.useFakeTimers(1519767013781);
+
+    config.setConfig({
+      s2sConfig: {
+        timeout: 1000,
+        accountId: 10000,
+      },
+      rubicon: {
+        wrapperName: '10000_fakewrapper_test'
+      }
+    })
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    config.resetConfig();
+  });
+
+  it('should require accountId', function () {
+    sandbox.stub(utils, 'logError');
+
+    rubiconAnalyticsAdapter.enableAnalytics({
+      options: {
+        endpoint: '//localhost:9999/event'
+      }
+    });
+
+    expect(utils.logError.called).to.equal(true);
+  });
+
+  it('should require endpoint', function () {
+    sandbox.stub(utils, 'logError');
+
+    rubiconAnalyticsAdapter.enableAnalytics({
+      options: {
+        accountId: 1001
+      }
+    });
+
+    expect(utils.logError.called).to.equal(true);
+  });
+
+  describe('sampling', function () {
+    beforeEach(function () {
+      sandbox.stub(Math, 'random').returns(0.08);
+      sandbox.stub(utils, 'logError');
+    });
+
+    afterEach(function () {
+      rubiconAnalyticsAdapter.disableAnalytics();
+    });
+
+    describe('with options.samplingFactor', function () {
+      it('should sample', function () {
+        rubiconAnalyticsAdapter.enableAnalytics({
+          options: {
+            endpoint: '//localhost:9999/event',
+            accountId: 1001,
+            samplingFactor: 10
+          }
+        });
+
+        performStandardAuction();
+
+        expect(requests.length).to.equal(1);
+      });
+
+      it('should unsample', function () {
+        rubiconAnalyticsAdapter.enableAnalytics({
+          options: {
+            endpoint: '//localhost:9999/event',
+            accountId: 1001,
+            samplingFactor: 20
+          }
+        });
+
+        performStandardAuction();
+
+        expect(requests.length).to.equal(0);
+      });
+
+      it('should throw errors for invalid samplingFactor', function () {
+        rubiconAnalyticsAdapter.enableAnalytics({
+          options: {
+            endpoint: '//localhost:9999/event',
+            accountId: 1001,
+            samplingFactor: 30
+          }
+        });
+
+        performStandardAuction();
+
+        expect(requests.length).to.equal(0);
+        expect(utils.logError.called).to.equal(true);
+      });
+    });
+    describe('with options.sampling', function () {
+      it('should sample', function () {
+        rubiconAnalyticsAdapter.enableAnalytics({
+          options: {
+            endpoint: '//localhost:9999/event',
+            accountId: 1001,
+            sampling: 0.1
+          }
+        });
+
+        performStandardAuction();
+
+        expect(requests.length).to.equal(1);
+      });
+
+      it('should unsample', function () {
+        rubiconAnalyticsAdapter.enableAnalytics({
+          options: {
+            endpoint: '//localhost:9999/event',
+            accountId: 1001,
+            sampling: 0.05
+          }
+        });
+
+        performStandardAuction();
+
+        expect(requests.length).to.equal(0);
+      });
+
+      it('should throw errors for invalid samplingFactor', function () {
+        rubiconAnalyticsAdapter.enableAnalytics({
+          options: {
+            endpoint: '//localhost:9999/event',
+            accountId: 1001,
+            sampling: 1 / 30
+          }
+        });
+
+        performStandardAuction();
+
+        expect(requests.length).to.equal(0);
+        expect(utils.logError.called).to.equal(true);
+      });
+    });
+  });
+
+  describe('when handling events', function () {
+    beforeEach(function () {
+      rubiconAnalyticsAdapter.enableAnalytics({
+        options: {
+          endpoint: '//localhost:9999/event',
+          accountId: 1001
+        }
+      });
+    });
+
+    afterEach(function () {
+      rubiconAnalyticsAdapter.disableAnalytics();
+    });
+
+    it('should build a batched message from prebid events', function () {
+      performStandardAuction();
+
+      expect(requests.length).to.equal(1);
+      let request = requests[0];
+
+      expect(request.url).to.equal('//localhost:9999/event');
+
+      let message = JSON.parse(request.requestBody);
+      validate(message);
+
+      expect(message).to.deep.equal(ANALYTICS_MESSAGE);
+    });
+
+    it('should pick the highest cpm bid if more than one bid per bidRequestId', function () {
+      // Only want one bid request in our mock auction
+      let bidRequested = utils.deepClone(MOCK.BID_REQUESTED);
+      bidRequested.bids.shift();
+      let auctionInit = utils.deepClone(MOCK.AUCTION_INIT);
+      auctionInit.adUnits.shift();
+
+      // clone the mock bidResponse and duplicate
+      let duplicateResponse1 = utils.deepClone(BID2);
+      duplicateResponse1.cpm = 1.0;
+      duplicateResponse1.adserverTargeting.hb_pb = '1.0';
+      duplicateResponse1.adserverTargeting.hb_adid = '1111';
+      let duplicateResponse2 = utils.deepClone(BID2);
+      duplicateResponse2.cpm = 5.5;
+      duplicateResponse2.adserverTargeting.hb_pb = '5.5';
+      duplicateResponse2.adserverTargeting.hb_adid = '5555';
+      let duplicateResponse3 = utils.deepClone(BID2);
+      duplicateResponse3.cpm = 0.1;
+      duplicateResponse3.adserverTargeting.hb_pb = '0.1';
+      duplicateResponse3.adserverTargeting.hb_adid = '3333';
+
+      const setTargeting = {
+        [duplicateResponse2.adUnitCode]: duplicateResponse2.adserverTargeting
+      };
+
+      const bidWon = Object.assign({}, duplicateResponse2, {
+        'status': 'rendered'
+      });
+
+      // spoof the auction with just our duplicates
+      events.emit(AUCTION_INIT, auctionInit);
+      events.emit(BID_REQUESTED, bidRequested);
+      events.emit(BID_RESPONSE, duplicateResponse1);
+      events.emit(BID_RESPONSE, duplicateResponse2);
+      events.emit(BID_RESPONSE, duplicateResponse3);
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+      events.emit(SET_TARGETING, setTargeting);
+      events.emit(BID_WON, bidWon);
+
+      let message = JSON.parse(requests[0].requestBody);
+      validate(message);
+      expect(message.auctions[0].adUnits[0].bids[0].bidResponse.bidPriceUSD).to.equal(5.5);
+      expect(message.auctions[0].adUnits[0].adserverTargeting.hb_pb).to.equal('5.5');
+      expect(message.auctions[0].adUnits[0].adserverTargeting.hb_adid).to.equal('5555');
+      expect(message.bidsWon.length).to.equal(1);
+      expect(message.bidsWon[0].bidResponse.bidPriceUSD).to.equal(5.5);
+      expect(message.bidsWon[0].adserverTargeting.hb_pb).to.equal('5.5');
+      expect(message.bidsWon[0].adserverTargeting.hb_adid).to.equal('5555');
+    });
+
+    it('should send batched message without BID_WON if necessary and further BID_WON events individually', function () {
+      events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
+      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
+      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
+      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[1]);
+      events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+      events.emit(SET_TARGETING, MOCK.SET_TARGETING);
+      events.emit(BID_WON, MOCK.BID_WON[0]);
+
+      clock.tick(SEND_TIMEOUT + 1000);
+
+      events.emit(BID_WON, MOCK.BID_WON[1]);
+
+      expect(requests.length).to.equal(2);
+
+      let message = JSON.parse(requests[0].requestBody);
+      validate(message);
+      expect(message.bidsWon.length).to.equal(1);
+      expect(message.auctions).to.deep.equal(ANALYTICS_MESSAGE.auctions);
+      expect(message.bidsWon[0]).to.deep.equal(ANALYTICS_MESSAGE.bidsWon[0]);
+
+      message = JSON.parse(requests[1].requestBody);
+      validate(message);
+      expect(message.bidsWon.length).to.equal(1);
+      expect(message).to.not.have.property('auctions');
+      expect(message.bidsWon[0]).to.deep.equal(ANALYTICS_MESSAGE.bidsWon[1]);
+    });
+
+    it('should properly mark bids as timed out', function () {
+      events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
+      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
+      events.emit(BID_TIMEOUT, MOCK.BID_TIMEOUT);
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+
+      clock.tick(SEND_TIMEOUT + 1000);
+
+      expect(requests.length).to.equal(1);
+
+      let message = JSON.parse(requests[0].requestBody);
+      validate(message);
+      let timedOutBid = message.auctions[0].adUnits[0].bids[0];
+      expect(timedOutBid.status).to.equal('error');
+      expect(timedOutBid.error.code).to.equal('timeout-error');
+      expect(timedOutBid).to.not.have.property('bidResponse');
+    });
+
+    it('should successfully convert bid price to USD in parseBidResponse', function () {
+      // Set the rates
+      setConfig({
+        adServerCurrency: 'JPY',
+        rates: {
+          USD: {
+            JPY: 100
+          }
+        }
+      });
+
+      // set our bid response to JPY
+      const bidCopy = utils.deepClone(BID2);
+      bidCopy.currency = 'JPY';
+      bidCopy.cpm = 100;
+
+      // Now add the bidResponse hook which hooks on the currenct conversion function onto the bid response
+      let innerBid;
+      addBidResponseHook(function(adCodeId, bid) {
+        innerBid = bid;
+      }, 'elementId', bidCopy);
+
+      // Use the rubi analytics parseBidResponse Function to get the resulting cpm from the bid response!
+      const bidResponseObj = parseBidResponse(innerBid);
+      expect(bidResponseObj).to.have.property('bidPriceUSD');
+      expect(bidResponseObj.bidPriceUSD).to.equal(1.0);
+    });
+  });
+
+  describe('config with integration type', () => {
+    it('should use the integration type provided in the config instead of the default', () => {
+      sandbox.stub(config, 'getConfig').callsFake(function (key) {
+        const config = {
+          'rubicon.int_type': 'testType'
+        };
+        return config[key];
+      });
+
+      rubiconAnalyticsAdapter.enableAnalytics({
+        options: {
+          endpoint: '//localhost:9999/event',
+          accountId: 1001
+        }
+      });
+
+      performStandardAuction();
+
+      expect(requests.length).to.equal(1);
+      const request = requests[0];
+      const message = JSON.parse(request.requestBody);
+      expect(message.integration).to.equal('testType');
+
+      rubiconAnalyticsAdapter.disableAnalytics();
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Re-add rubicon analytics adapter and update to meet standards for Prebid 3.0
Removed use of deprecated getTopWindowUrl util

Only looks like I added the entire analytics adapter since merging Prebid `master` into the fork deleted the files.
[rubiconAnalyticsAdapter.js diff](https://github.com/rubicon-project/Prebid.js/compare/842e45f..4e1679b#diff-7eda04fa0d03f759128e98228a4d9ed5)
[rubiconAnalyticsAdapter_spec.js diff](https://github.com/rubicon-project/Prebid.js/compare/842e45f..4e1679b#diff-cce10d7ccb060d61dbbe364332728868)

<img width="1079" alt="Screen Shot 2019-12-17 at 2 22 19 PM" src="https://user-images.githubusercontent.com/51493331/71027162-b5012f80-20d8-11ea-81c2-7624be70fc74.png">

<img width="1126" alt="Screen Shot 2019-12-17 at 2 21 57 PM" src="https://user-images.githubusercontent.com/51493331/71027168-b894b680-20d8-11ea-94b7-e9aab1b06619.png">
