### PR TITLE
Carbon RTD & Analytics modules

### DIFF
--- a/modules/carbonAnalyticsAdapter.js
+++ b/modules/carbonAnalyticsAdapter.js
@@ -253,7 +253,8 @@ function sendEngagementEvent(event, eventTrigger) {
     JSON.stringify(event),
     {
       contentType: 'application/json',
-      method: 'POST'
+      method: 'POST',
+      withCredentials: true
     }
   );
 };

--- a/modules/carbonAnalyticsAdapter.js
+++ b/modules/carbonAnalyticsAdapter.js
@@ -254,7 +254,8 @@ function sendEngagementEvent(event, eventTrigger) {
     {
       contentType: 'application/json',
       method: 'POST',
-      withCredentials: true
+      withCredentials: true,
+      crossOrigin: true
     }
   );
 };

--- a/modules/carbonAnalyticsAdapter.js
+++ b/modules/carbonAnalyticsAdapter.js
@@ -237,6 +237,8 @@ function sendEngagementEvent(event, eventTrigger) {
         }
 
         if (userData?.update && userData?.id != '') {
+          profileId = userData.id;
+
           if (storage.cookiesAreEnabled()) {
             storage.setCookie(PROFILE_ID_COOKIE, userData.id, new Date(Date.now() + 89 * DAY_MS), 'Lax');
           }

--- a/modules/carbonAnalyticsAdapter.js
+++ b/modules/carbonAnalyticsAdapter.js
@@ -80,6 +80,7 @@ carbonAdapter.enableAnalytics = function (config) {
     ttl: 60, // unit is seconds
     count: 0,
     id: generateUUID(),
+    startTime: Date.now(),
     timeLastEngage: Date.now()
   };
 
@@ -167,6 +168,7 @@ function registerEngagement() {
   }
 
   pageEngagement.count++;
+  pageEngagement.startTime = present;
   pageEngagement.id = generateUUID();
 };
 
@@ -221,12 +223,12 @@ function createBaseEngagementEvent(args) {
   event.engagement_id = pageEngagement.id;
   event.engagement_count = pageEngagement.count;
   event.engagement_ttl = pageEngagement.ttl;
+  event.start_time = pageEngagement.startTime;
+  event.end_time = Date.now();
 
   event.script_id = window.location.host;
   event.url = window.location.href;
   event.referrer = document.referrer || deepAccess(args, 'bidderRequests.0.refererInfo.page') || undefined;
-
-  event.received_at = Date.now();
 
   if (args?.bidderRequests) {
     event.consent = getConsentData(args);

--- a/modules/carbonAnalyticsAdapter.js
+++ b/modules/carbonAnalyticsAdapter.js
@@ -126,6 +126,20 @@ function getProfileId() {
   return newId;
 }
 
+function updateProfileId(userData) {
+  if (userData?.update && userData?.id != '') {
+    profileId = userData.id;
+
+    if (storage.cookiesAreEnabled()) {
+      storage.setCookie(PROFILE_ID_COOKIE, userData.id, new Date(Date.now() + 89 * DAY_MS), 'Lax');
+    }
+
+    if (storage.localStorageIsEnabled()) {
+      storage.setDataInLocalStorage(PROFILE_ID_KEY, userData.id);
+    }
+  }
+}
+
 function getSessionId() {
   if (storage.cookiesAreEnabled()) {
     let cookieId = storage.getCookie(SESSION_ID_COOKIE);
@@ -232,20 +246,9 @@ function sendEngagementEvent(event, eventTrigger) {
 
         try {
           userData = JSON.parse(response);
+          updateProfileId(userData);
         } catch (e) {
           logError('unable to parse API response');
-        }
-
-        if (userData?.update && userData?.id != '') {
-          profileId = userData.id;
-
-          if (storage.cookiesAreEnabled()) {
-            storage.setCookie(PROFILE_ID_COOKIE, userData.id, new Date(Date.now() + 89 * DAY_MS), 'Lax');
-          }
-
-          if (storage.localStorageIsEnabled()) {
-            storage.setDataInLocalStorage(PROFILE_ID_KEY, userData.id);
-          }
         }
       },
       error: error => {

--- a/modules/carbonRtdProvider.js
+++ b/modules/carbonRtdProvider.js
@@ -22,7 +22,6 @@ const TAXONOMY_RULE_EXPIRATION_KEY = 'carbon_ct_expiration'
 let rtdHost = '';
 let parentId = '';
 let features = {};
-let taxonomyRuleTTL = 600000; // default value of 10 minutes, can be overriden by config
 
 export const storage = getStorageManager({ gvlid: CARBON_GVL_ID, moduleName: SUBMODULE_NAME })
 
@@ -31,8 +30,8 @@ export function setLocalStorage(carbonData) {
   storage.setDataInLocalStorage(STORAGE_KEY, data);
 }
 
-export function setTaxonomyRuleExpiration() {
-  let expiration = Date.now() + taxonomyRuleTTL;
+export function setTaxonomyRuleExpiration(customTaxonomyTTL) {
+  let expiration = Date.now() + customTaxonomyTTL;
   storage.setDataInLocalStorage(TAXONOMY_RULE_EXPIRATION_KEY, expiration);
 }
 
@@ -203,8 +202,8 @@ export function updateRealTimeDataAsync(callback, taxonomyRules) {
         // if custom taxonomy didn't expire use the existing data
         if (taxonomyRules?.length && carbonData?.context) {
           carbonData.context.customTaxonomy = taxonomyRules;
-        } else {
-          setTaxonomyRuleExpiration();
+        } else if (carbonData.context?.customTaxonomyTTL > 0) {
+          setTaxonomyRuleExpiration(carbonData.context?.customTaxonomyTTL);
         }
 
         updateProfileId(carbonData);
@@ -268,7 +267,6 @@ function init(moduleConfig, userConsent) {
     return false;
   }
 
-  taxonomyRuleTTL = moduleConfig?.params?.cacheTTL || taxonomyRuleTTL;
   features = moduleConfig?.params?.features || features;
 
   return true;

--- a/modules/carbonRtdProvider.js
+++ b/modules/carbonRtdProvider.js
@@ -213,6 +213,7 @@ export function updateRealTimeDataAsync(callback, taxonomyRules) {
   null, {
     method: 'GET',
     withCredentials: true,
+    crossOrigin: true
   });
 }
 

--- a/modules/carbonRtdProvider.js
+++ b/modules/carbonRtdProvider.js
@@ -209,6 +209,10 @@ export function updateRealTimeDataAsync(callback, taxonomyRules) {
     error: function () {
       logError('failed to retrieve targeting information');
     }
+  },
+  null, {
+    method: 'GET',
+    withCredentials: true,
   });
 }
 

--- a/modules/carbonRtdProvider.js
+++ b/modules/carbonRtdProvider.js
@@ -36,7 +36,14 @@ export function setTaxonomyRuleExpiration() {
   storage.setDataInLocalStorage(TAXONOMY_RULE_EXPIRATION_KEY, expiration);
 }
 
-export function matchCustomTaxonomyRule (rule) {
+export function updateProfileId(carbonData) {
+  let identity = carbonData?.profile?.identity;
+  if (identity?.update && identity?.id != '' && storage.localStorageIsEnabled()) {
+    storage.setDataInLocalStorage(PROFILE_ID_KEY, identity.id);
+  }
+}
+
+export function matchCustomTaxonomyRule(rule) {
   const contentText = window.top.document.body.innerText;
   if (rule.MatchType == 'any') {
     let words = Object.keys(rule.WordWeights).join('|');
@@ -200,6 +207,7 @@ export function updateRealTimeDataAsync(callback, taxonomyRules) {
           setTaxonomyRuleExpiration();
         }
 
+        updateProfileId(carbonData);
         setPrebidConfig(carbonData);
         prepareGPTTargeting(carbonData);
         setLocalStorage(carbonData);

--- a/test/spec/modules/carbonAnalyticsAdapter_spec.js
+++ b/test/spec/modules/carbonAnalyticsAdapter_spec.js
@@ -72,7 +72,7 @@ describe('carbonAnalyticsAdapter', function() {
       expect(requestBody.engagement_id).to.equal('test_engagement_id')
       expect(requestBody.engagement_count).to.equal(0)
       expect(requestBody.engagement_ttl).to.equal(60)
-      expect(requestBody.received_at).to.equal(1000000000000)
+      expect(requestBody.start_time).to.equal(1000000000000)
     })
   })
 
@@ -107,7 +107,7 @@ describe('carbonAnalyticsAdapter', function() {
       const tcfEnforcementBody = JSON.parse(ajaxStub.firstCall.args[2])
 
       expect(tcfEnforcementUrl.pathname).to.equal('/v1.0/parent/aaabbb/engagement/trigger/tcf_enforcement')
-      expect(tcfEnforcementBody.received_at).to.equal(1000000000000)
+      expect(tcfEnforcementBody.start_time).to.equal(1000000000000)
 
       const auctionEndUrl = new URL(ajaxStub.secondCall.args[0])
       const auctionEndBody = JSON.parse(ajaxStub.secondCall.args[2])
@@ -115,7 +115,7 @@ describe('carbonAnalyticsAdapter', function() {
       expect(auctionEndUrl.pathname).to.equal('/v1.0/parent/aaabbb/engagement/trigger/auction_end')
       expect(auctionEndBody.consent.gdpr_consent).to.equal('testGDPR')
       expect(auctionEndBody.consent.ccpa_consent).to.equal('testUSP')
-      expect(auctionEndBody.received_at).to.equal(1000000000000)
+      expect(auctionEndBody.start_time).to.equal(1000000000000)
     })
 
     it('should generate a new engagement', function() {
@@ -135,7 +135,7 @@ describe('carbonAnalyticsAdapter', function() {
       const tcfEnforcementBody = JSON.parse(ajaxStub.firstCall.args[2])
 
       expect(tcfEnforcementUrl.pathname).to.equal('/v1.0/parent/aaabbb/engagement/trigger/tcf_enforcement')
-      expect(tcfEnforcementBody.received_at).to.equal(1000001000010)
+      expect(tcfEnforcementBody.end_time).to.equal(1000001000010)
 
       const auctionEndUrl = new URL(ajaxStub.secondCall.args[0])
       const auctionEndBody = JSON.parse(ajaxStub.secondCall.args[2])
@@ -146,7 +146,7 @@ describe('carbonAnalyticsAdapter', function() {
       expect(auctionEndBody.engagement_id).to.equal('test_engagement_id_2')
       expect(auctionEndBody.engagement_count).to.equal(1)
       expect(auctionEndBody.engagement_ttl).to.equal(60)
-      expect(auctionEndBody.received_at).to.equal(1000001000020)
+      expect(auctionEndBody.end_time).to.equal(1000001000020)
     })
   })
 })

--- a/test/spec/modules/carbonRtdProvider_spec.js
+++ b/test/spec/modules/carbonRtdProvider_spec.js
@@ -12,6 +12,10 @@ import { carbonSubmodule,
 
 const targetingData = {
   profile: {
+    identity: {
+      id: '7d40ac1d-e7d2-4979-90a1-6204b80d12f5',
+      update: true
+    },
     audiences: [
       '3049feb1-4c23-487c-a2f3-9437f65a782f',
       '93f8f5e6-6219-4c44-83d1-3e14b83b4177'

--- a/test/spec/modules/carbonRtdProvider_spec.js
+++ b/test/spec/modules/carbonRtdProvider_spec.js
@@ -247,6 +247,7 @@ describe('carbonRtdProvider', function() {
       let callbackStub = sinon.stub()
 
       storage.setDataInLocalStorage('carbon_ccuid', 'a7939741-8a3c-4476-9138-b3fb73edc885')
+      storage.setDataInLocalStorage('carbon_ct_expiration', Date.now() + 600000)
       setLocalStorage(targetingData)
 
       bidRequestHandler({}, callbackStub, moduleConfig, {})

--- a/test/spec/modules/carbonRtdProvider_spec.js
+++ b/test/spec/modules/carbonRtdProvider_spec.js
@@ -69,6 +69,7 @@ const targetingData = {
         }
       }
     ],
+    customTaxonomyTTL: 600000,
     dealIds: [
       'deal1',
       'deal2'


### PR DESCRIPTION
This change will add the modules to support Carbon for Prebid.

The modules include the Real Time Data module carbonRtdProvider.js and the Analytics module carbonAnalyticsAdapter.js.

Unit tests have been included, the Real Time Data module achieving 83.03% coverage & the Analytics module achieving 93.63% coverage.